### PR TITLE
Fixed bug #11 - Границы поля логина и пароля становятся невидимыми

### DIFF
--- a/libs/core/auth/data-access/src/lib/+state/auth.effects.ts
+++ b/libs/core/auth/data-access/src/lib/+state/auth.effects.ts
@@ -101,7 +101,9 @@ export const logoutEffect$ = createEffect(
       ofType(authActions.logout),
       tap(() => {
         jwtService.removeItem();
-        router.navigate(['/login'])
+        router.navigate(['/login']);
+        const notDefaultTheme: Element | null = document.head.querySelector('.style-manager-theme');
+        if (notDefaultTheme) notDefaultTheme.remove();
       })
     )
   ), { functional: true, dispatch: false }


### PR DESCRIPTION
Баг #11 - Границы поля логина и пароля становятся невидимыми.

Проблема была в том, что после выхода из системы в <head> оставался html-элемент стиля <link rel="stylesheet"..."dark-red.css"> (и остальные темные темы) и влиял на все элементы страница авторизации.

Предлагаемое решение: удалить из <head> этот html-элемент стиля в конце срабатывания эффекта logoutEffect$.