### PR TITLE
#2 feature: materials feature for Materials task

### DIFF
--- a/apps/users/src/app/app.config.ts
+++ b/apps/users/src/app/app.config.ts
@@ -20,6 +20,7 @@ import { articlesEffects, articlesFeature, commentsEffects, commentsFeature } fr
 import { tasksEffects, tasksFeature } from '@users/users/task/data-access';
 import { CLIENT_ID, githubApiEffects, githubApiFeature } from '@users/core/github-api/data-access';
 import { backlogFeature, backlogEffects } from '@users/users/backlog/data-access';
+import { MaterialsEffects, materialsFeature } from '@users/materials/data-access';
 
 export function HttpLoaderFactory(http: HttpClient) {
   return new TranslateHttpLoader(http);
@@ -35,7 +36,8 @@ export const appConfig: ApplicationConfig = {
       commentsEffects,
       githubApiEffects,
       backlogEffects,
-      SettingsEffects
+      SettingsEffects,
+      MaterialsEffects
     ),
     provideStore({
       router: routerReducer,
@@ -47,6 +49,7 @@ export const appConfig: ApplicationConfig = {
       [tasksFeature.name]: tasksFeature.reducer,
       [githubApiFeature.name]: githubApiFeature.reducer,
       [backlogFeature.name]: backlogFeature.reducer,
+      [materialsFeature.name]: materialsFeature.reducer
     }),
     provideRouterStore(),
     provideStoreDevtools({

--- a/apps/users/src/app/app.routes.ts
+++ b/apps/users/src/app/app.routes.ts
@@ -52,6 +52,10 @@ export const appRoutes: Route[] = [
         loadComponent: () => import('@users/materials/feature-folders-list').then((c) => c.FoldersListContainerComponent),
       },
       {
+      path: 'materials/:id',
+      loadComponent: () => import('@users/materials/feature-materials-list').then((c) => c.MaterialsListContainerComponent),
+      },
+      {
         path: 'articles',
         loadComponent: () => import('@users/users/articles/articles').then((c) => c.ArticlesViewContainerComponent),
       },

--- a/apps/users/src/app/app.routes.ts
+++ b/apps/users/src/app/app.routes.ts
@@ -49,7 +49,7 @@ export const appRoutes: Route[] = [
       },
       {
         path: 'materials',
-        loadComponent: () => import('@users/materials').then((c) => c.UsersMaterialsComponent),
+        loadComponent: () => import('@users/materials/feature-folders-list').then((c) => c.FoldersListContainerComponent),
       },
       {
         path: 'articles',

--- a/libs/users/materials/data-access/src/index.ts
+++ b/libs/users/materials/data-access/src/index.ts
@@ -1,1 +1,7 @@
-export * from './lib/users-materials-data-access/users-materials-data-access.component';
+export * from './lib/models/folders.interface';
+export * from './lib/models/materials.interface';
+export * from './lib/+state/materials.actions';
+export * from './lib/+state/materials.effects';
+// export * from './lib/+state/materials.facade';
+export * from './lib/+state/materials.reducer';
+export * from './lib/+state/materials.selectors';

--- a/libs/users/materials/data-access/src/index.ts
+++ b/libs/users/materials/data-access/src/index.ts
@@ -2,6 +2,6 @@ export * from './lib/models/folders.interface';
 export * from './lib/models/materials.interface';
 export * from './lib/+state/materials.actions';
 export * from './lib/+state/materials.effects';
-// export * from './lib/+state/materials.facade';
+export * from './lib/+state/materials.facade';
 export * from './lib/+state/materials.reducer';
 export * from './lib/+state/materials.selectors';

--- a/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
@@ -16,5 +16,11 @@ export const MaterialsActions = createActionGroup({
     'Delete Folder': props<{ folderId: number }>(),
     'Delete Folder Success': props<{ folderId: number }>(),
     'Delete Folder Failure': props<{ error: Error }>(),
+
+    'Open Folder': props<{ folderId: number }>(),
+
+    'Load Materials': props<{ folderId: number }>(),
+    'Load Materials Success': props<{ materials: Material[] }>(),
+    'Load Materials Failure': props<{ error: Error }>(),
   },
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
@@ -1,10 +1,12 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import { Folder } from '../models/folders.interface';
+import { Material } from '../models/materials.interface';
 
 export const MaterialsActions = createActionGroup({
   source: 'Materials',
   events: {
-    'Load Materialss': emptyProps(),
-    'Load Materialss Success': props<{ data: unknown }>(),
-    'Load Materialss Failure': props<{ error: unknown }>(),
+    'Load Folders': emptyProps(),
+    'Load Folders Success': props<{ folders: Folder[] }>(),
+    'Load Folders Failure': props<{ error: Error }>(),
   },
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
@@ -1,5 +1,5 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
-import { Folder } from '../models/folders.interface';
+import { Folder, newFolder } from '../models/folders.interface';
 import { Material } from '../models/materials.interface';
 
 export const MaterialsActions = createActionGroup({
@@ -8,5 +8,9 @@ export const MaterialsActions = createActionGroup({
     'Load Folders': emptyProps(),
     'Load Folders Success': props<{ folders: Folder[] }>(),
     'Load Folders Failure': props<{ error: Error }>(),
+
+    'Create Folder': props<{ folder: newFolder }>(),
+    'Create Folder Success': props<{ folder: Folder }>(),
+    'Create Folder Failure': props<{ error: Error }>(),
   },
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
@@ -1,6 +1,6 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
 import { Folder, newFolder } from '../models/folders.interface';
-import { Material } from '../models/materials.interface';
+import { Material, newMaterial } from '../models/materials.interface';
 
 export const MaterialsActions = createActionGroup({
   source: 'Materials',
@@ -22,5 +22,9 @@ export const MaterialsActions = createActionGroup({
     'Load Materials': props<{ folderId: number }>(),
     'Load Materials Success': props<{ materials: Material[] }>(),
     'Load Materials Failure': props<{ error: Error }>(),
+
+    'Create Material': props<{ material: newMaterial }>(),
+    'Create Material Success': props<{ material: Material }>(),
+    'Create Material Failure': props<{ error: Error }>(),
   },
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
@@ -12,5 +12,9 @@ export const MaterialsActions = createActionGroup({
     'Create Folder': props<{ folder: newFolder }>(),
     'Create Folder Success': props<{ folder: Folder }>(),
     'Create Folder Failure': props<{ error: Error }>(),
+
+    'Delete Folder': props<{ folderId: number }>(),
+    'Delete Folder Success': props<{ folderId: number }>(),
+    'Delete Folder Failure': props<{ error: Error }>(),
   },
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.actions.ts
@@ -26,5 +26,9 @@ export const MaterialsActions = createActionGroup({
     'Create Material': props<{ material: newMaterial }>(),
     'Create Material Success': props<{ material: Material }>(),
     'Create Material Failure': props<{ error: Error }>(),
+
+    'Delete Material': props<{ materialId: number }>(),
+    'Delete Material Success': props<{ materialId: number }>(),
+    'Delete Material Failure': props<{ error: Error }>(),
   },
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
@@ -41,4 +41,19 @@ export class MaterialsEffects {
       )
     );
   });
+
+  deleteFolder = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(MaterialsActions.deleteFolder),
+      switchMap(({ folderId }) => 
+        this.apiService.delete<void>(`/folder/${folderId}`).pipe(
+          map(() => MaterialsActions.deleteFolderSuccess({ folderId })),
+          catchError((error) => 
+            of(MaterialsActions.deleteFolderFailure({ error }))
+          )
+        )
+      )
+    );
+  });
+  
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
@@ -1,23 +1,28 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { catchError, map, concatMap } from 'rxjs/operators';
-import { Observable, EMPTY, of } from 'rxjs';
+import { catchError, map, mergeMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 import { MaterialsActions } from './materials.actions';
+import { ApiService } from '@users/core/http';
+import { Folder } from '../models/folders.interface';
 
 @Injectable()
 export class MaterialsEffects {
-  loadMaterialss$ = createEffect(() => {
+
+  private actions$ = inject(Actions);
+  private apiService = inject(ApiService);
+
+  loadFolders$ = createEffect(() => {
     return this.actions$.pipe(
-      ofType(MaterialsActions.loadMaterialss),
-      concatMap(() =>
-        /** An EMPTY observable only emits completion. Replace with your own observable API request */
-        EMPTY.pipe(
-          map((data) => MaterialsActions.loadMaterialssSuccess({ data })),
-          catchError((error) => of(MaterialsActions.loadMaterialssFailure({ error })))
-        )
+      ofType(MaterialsActions.loadFolders),
+      mergeMap(() => this.apiService.get<Folder[]>('/folder').pipe(
+        map((folders) => MaterialsActions.loadFoldersSuccess({ folders })),
+        catchError((error) => {
+          console.log('Error: ', error);
+          return of(MaterialsActions.loadFoldersFailure({ error }));
+        })
+      )
       )
     );
   });
-
-  constructor(private actions$: Actions) {}
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
@@ -1,10 +1,10 @@
 import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { catchError, map, mergeMap } from 'rxjs/operators';
+import { catchError, map, mergeMap, switchMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { MaterialsActions } from './materials.actions';
 import { ApiService } from '@users/core/http';
-import { Folder } from '../models/folders.interface';
+import { Folder, newFolder } from '../models/folders.interface';
 
 @Injectable()
 export class MaterialsEffects {
@@ -22,6 +22,22 @@ export class MaterialsEffects {
           return of(MaterialsActions.loadFoldersFailure({ error }));
         })
       )
+      )
+    );
+  });
+
+  createFolder$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(MaterialsActions.createFolder),
+      switchMap((action) => 
+        this.apiService.post<Folder, newFolder>('/folder', action.folder).pipe(
+          map((createdFolder) => 
+            MaterialsActions.createFolderSuccess({ folder: createdFolder })
+          ),
+          catchError((error) => 
+            of(MaterialsActions.createFolderFailure({ error }))
+          )
+        )
       )
     );
   });

--- a/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
@@ -96,4 +96,17 @@ export class MaterialsEffects {
     )
   );
   
+  deleteMaterial = createEffect(() =>
+    this.actions$.pipe(
+      ofType(MaterialsActions.deleteMaterial),
+      switchMap(({ materialId }) => 
+        this.apiService.delete<void>(`/material/${materialId}`).pipe(
+          map(() => MaterialsActions.deleteMaterialSuccess({ materialId })),
+          catchError((error) => 
+            of(MaterialsActions.deleteFolderFailure({ error }))
+          )
+        )
+      )
+    )
+  );
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { catchError, map, mergeMap, switchMap, withLatestFrom } from 'rxjs/operators';
+import { catchError, map, mergeMap, switchMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { MaterialsActions } from './materials.actions';
 import { ApiService } from '@users/core/http';

--- a/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.effects.ts
@@ -6,7 +6,7 @@ import { MaterialsActions } from './materials.actions';
 import { ApiService } from '@users/core/http';
 import { Folder, newFolder } from '../models/folders.interface';
 import { Store } from '@ngrx/store';
-import { Material } from '../models/materials.interface';
+import { Material, newMaterial } from '../models/materials.interface';
 
 @Injectable()
 export class MaterialsEffects {
@@ -79,4 +79,21 @@ export class MaterialsEffects {
       )
     )
   );
+
+  createMaterial = createEffect(() =>
+    this.actions$.pipe(
+      ofType(MaterialsActions.createMaterial),
+      switchMap((action) => 
+        this.apiService.post<Material, newMaterial>('/material', action.material).pipe(
+          map((createdMaterial) => 
+            MaterialsActions.createMaterialSuccess({ material: createdMaterial })
+          ),
+          catchError((error) => 
+            of(MaterialsActions.createMaterialFailure({ error }))
+          )
+        )
+      )
+    )
+  );
+  
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
@@ -4,6 +4,7 @@ import { MaterialsActions } from './materials.actions';
 import * as MaterialsSelectors from './materials.selectors';
 import { Observable } from 'rxjs';
 import { Folder, newFolder } from '../models/folders.interface';
+import { Material } from '../models/materials.interface';
 
 @Injectable({ providedIn: 'root' })
 
@@ -11,8 +12,10 @@ export class MaterialsFacade {
     private readonly store = inject(Store);
 
     public readonly allFolders: Observable<Folder[]> = this.store.select(MaterialsSelectors.selectFolders);
+    public readonly allMaterials: Observable<Material[]> = this.store.select(MaterialsSelectors.selectMaterials);
     public readonly loading$: Observable<boolean> = this.store.select(state => state.materials.loading);
     public readonly error$: Observable<string | null> = this.store.select(state => state.materials.error);
+    public readonly selectedFolderId$: Observable<number | null> = this.store.select(MaterialsSelectors.selectSelectedFolderId)
 
     loadFolders() {
         this.store.dispatch(MaterialsActions.loadFolders());
@@ -29,5 +32,10 @@ export class MaterialsFacade {
 
     openFolder(folderId: number) {
         this.store.dispatch(MaterialsActions.openFolder({folderId}))
+    }
+
+    loadMaterials(folderId: number) {
+        this.store.dispatch(MaterialsActions.loadMaterials({folderId}));
+        return this.allMaterials;
     }
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { MaterialsActions } from './materials.actions';
+import * as MaterialsSelectors from './materials.selectors';
+import { Observable } from 'rxjs';
+import { Folder } from '../models/folders.interface';
+
+@Injectable({ providedIn: 'root' })
+
+export class MaterialsFacade {
+    private readonly store = inject(Store);
+
+    public readonly allFolders: Observable<Folder[]> = this.store.select(MaterialsSelectors.selectFolders);
+    public readonly loading$: Observable<boolean> = this.store.select(state => state.materials.loading);
+    public readonly error$: Observable<string | null> = this.store.select(state => state.materials.error);
+
+    loadFolders() {
+        this.store.dispatch(MaterialsActions.loadFolders());
+        return this.allFolders;
+    }
+}

--- a/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
@@ -4,7 +4,7 @@ import { MaterialsActions } from './materials.actions';
 import * as MaterialsSelectors from './materials.selectors';
 import { Observable } from 'rxjs';
 import { Folder, newFolder } from '../models/folders.interface';
-import { Material } from '../models/materials.interface';
+import { Material, newMaterial } from '../models/materials.interface';
 
 @Injectable({ providedIn: 'root' })
 
@@ -37,5 +37,9 @@ export class MaterialsFacade {
     loadMaterials(folderId: number) {
         this.store.dispatch(MaterialsActions.loadMaterials({folderId}));
         return this.allMaterials;
+    }
+
+    createMaterial(material: newMaterial) {
+        this.store.dispatch(MaterialsActions.createMaterial({material}));
     }
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
@@ -22,4 +22,8 @@ export class MaterialsFacade {
     createFolder(folder: newFolder) {
         this.store.dispatch(MaterialsActions.createFolder({folder}));
     }
+
+    deleteFolder(folderId: number) {
+        this.store.dispatch(MaterialsActions.deleteFolder({folderId}))
+    }
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
@@ -26,4 +26,8 @@ export class MaterialsFacade {
     deleteFolder(folderId: number) {
         this.store.dispatch(MaterialsActions.deleteFolder({folderId}))
     }
+
+    openFolder(folderId: number) {
+        this.store.dispatch(MaterialsActions.openFolder({folderId}))
+    }
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { MaterialsActions } from './materials.actions';
 import * as MaterialsSelectors from './materials.selectors';
 import { Observable } from 'rxjs';
-import { Folder } from '../models/folders.interface';
+import { Folder, newFolder } from '../models/folders.interface';
 
 @Injectable({ providedIn: 'root' })
 
@@ -17,5 +17,9 @@ export class MaterialsFacade {
     loadFolders() {
         this.store.dispatch(MaterialsActions.loadFolders());
         return this.allFolders;
+    }
+
+    createFolder(folder: newFolder) {
+        this.store.dispatch(MaterialsActions.createFolder({folder}));
     }
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.facade.ts
@@ -42,4 +42,8 @@ export class MaterialsFacade {
     createMaterial(material: newMaterial) {
         this.store.dispatch(MaterialsActions.createMaterial({material}));
     }
+
+    deleteMaterial(materialId: number) {
+        this.store.dispatch(MaterialsActions.deleteMaterial({materialId}))
+    }
 }

--- a/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
@@ -90,5 +90,15 @@ export const materialsFeature = createFeature({
       loading: false,
       error: String(error)
     })),
+    on(MaterialsActions.deleteMaterial, (state, { materialId }) => ({
+      ...state,
+      materials: state.materials.filter(material => material.id !== materialId),
+      loading:false
+    })),
+    on(MaterialsActions.deleteMaterialFailure, (state, { error }) => ({
+      ...state,
+      loading: false,
+      error: String(error)
+    })),
   ),
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
@@ -8,6 +8,7 @@ export const MATERIALS_FEATURE_KEY = 'materials';
 export interface MaterialsState {
   folders: Folder[];
   materials: Material[];
+  selectedFolderId: number | null;
   loading: boolean;
   error: string | null;
 }
@@ -15,6 +16,7 @@ export interface MaterialsState {
 export const initialMaterialsState: MaterialsState = {
   folders: [],
   materials: [],
+  selectedFolderId: null,
   loading: false,
   error: null
 };
@@ -59,8 +61,9 @@ export const materialsFeature = createFeature({
       loading: false,
       error: String(error)
     })),
-    on(MaterialsActions.openFolder, (state) =>({
+    on(MaterialsActions.openFolder, (state, {folderId}) =>({
       ...state,
+      selectedFolderId: folderId,
       loading: true
     })),
     on(MaterialsActions.loadMaterials, (state) => ({

--- a/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
@@ -1,17 +1,20 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
 import { MaterialsActions } from './materials.actions';
 import { Folder } from '../models/folders.interface';
+import { Material } from '../models/materials.interface';
 
 export const MATERIALS_FEATURE_KEY = 'materials';
 
 export interface MaterialsState {
   folders: Folder[];
+  materials: Material[];
   loading: boolean;
   error: string | null;
 }
 
 export const initialMaterialsState: MaterialsState = {
   folders: [],
+  materials: [],
   loading: false,
   error: null
 };
@@ -52,6 +55,25 @@ export const materialsFeature = createFeature({
       loading:false
     })),
     on(MaterialsActions.deleteFolderFailure, (state, { error }) => ({
+      ...state,
+      loading: false,
+      error: String(error)
+    })),
+    on(MaterialsActions.openFolder, (state) =>({
+      ...state,
+      loading: true
+    })),
+    on(MaterialsActions.loadMaterials, (state) => ({
+      ...state,
+      loading: true,
+      error: null
+    })),
+    on(MaterialsActions.loadMaterialsSuccess, (state, { materials }) => ({
+      ...state,
+      materials,
+      loading: false
+    })),
+    on(MaterialsActions.loadMaterialsFailure, (state, { error }) => ({
       ...state,
       loading: false,
       error: String(error)

--- a/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
@@ -81,5 +81,14 @@ export const materialsFeature = createFeature({
       loading: false,
       error: String(error)
     })),
+    on(MaterialsActions.createMaterialSuccess, (state, { material }) => ({
+      ...state,
+      materials: [...state.materials, material]
+    })),
+    on(MaterialsActions.createMaterialFailure, (state, { error }) => ({
+      ...state,
+      loading: false,
+      error: String(error)
+    })),
   ),
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
@@ -1,20 +1,39 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
 import { MaterialsActions } from './materials.actions';
+import { Folder } from '../models/folders.interface';
 
-export const materialsFeatureKey = 'materials';
+export const MATERIALS_FEATURE_KEY = 'materials';
 
-export interface State {}
+export interface MaterialsState {
+  folders: Folder[];
+  loading: boolean;
+  error: string | null;
+}
 
-export const initialState: State = {};
-
-export const reducer = createReducer(
-  initialState,
-  on(MaterialsActions.loadMaterialss, (state) => state),
-  on(MaterialsActions.loadMaterialssSuccess, (state, action) => state),
-  on(MaterialsActions.loadMaterialssFailure, (state, action) => state)
-);
+export const initialMaterialsState: MaterialsState = {
+  folders: [],
+  loading: false,
+  error: null
+};
 
 export const materialsFeature = createFeature({
-  name: materialsFeatureKey,
-  reducer,
+  name: MATERIALS_FEATURE_KEY,
+  reducer: createReducer(
+    initialMaterialsState,
+    on(MaterialsActions.loadFolders, (state) => ({
+      ...state,
+      loading: true,
+      error: null
+    })),
+    on(MaterialsActions.loadFoldersSuccess, (state, { folders }) => ({
+      ...state,
+      folders,
+      loading: false
+    })),
+    on(MaterialsActions.loadFoldersFailure, (state, { error }) => ({
+      ...state,
+      loading: false,
+      error: String(error)
+  }))
+  ),
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
@@ -46,5 +46,15 @@ export const materialsFeature = createFeature({
       loading: false,
       error: String(error)
     })),
+    on(MaterialsActions.deleteFolder, (state, { folderId }) => ({
+      ...state,
+      folders: state.folders.filter(folder => folder.id !== folderId),
+      loading:false
+    })),
+    on(MaterialsActions.deleteFolderFailure, (state, { error }) => ({
+      ...state,
+      loading: false,
+      error: String(error)
+    })),
   ),
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.reducer.ts
@@ -34,6 +34,17 @@ export const materialsFeature = createFeature({
       ...state,
       loading: false,
       error: String(error)
-  }))
+    })),
+    on(MaterialsActions.createFolderSuccess, (state, {folder}) => ({
+      ...state,
+      folders: [...state.folders, folder],
+      loading: false,
+      error: null
+    })),
+    on(MaterialsActions.createFolderFailure, (state, { error }) => ({
+      ...state,
+      loading: false,
+      error: String(error)
+    })),
   ),
 });

--- a/libs/users/materials/data-access/src/lib/+state/materials.selectors.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.selectors.ts
@@ -1,10 +1,16 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import * as materialsReducers from './materials.reducer';
 import { Folder } from '../models/folders.interface';
+import { Material } from '../models/materials.interface';
 
 export const selectMaterialsState = createFeatureSelector<materialsReducers.MaterialsState>(materialsReducers.MATERIALS_FEATURE_KEY);
 
 export const selectFolders = createSelector(
   selectMaterialsState,
   (state): Folder[] => state.folders
+);
+
+export const selectMaterials = createSelector(
+  selectMaterialsState,
+  (state): Material[] => state.materials
 );

--- a/libs/users/materials/data-access/src/lib/+state/materials.selectors.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.selectors.ts
@@ -14,3 +14,8 @@ export const selectMaterials = createSelector(
   selectMaterialsState,
   (state): Material[] => state.materials
 );
+
+export const selectSelectedFolderId = createSelector(
+  selectMaterialsState,
+  (state) => state.selectedFolderId
+)

--- a/libs/users/materials/data-access/src/lib/+state/materials.selectors.ts
+++ b/libs/users/materials/data-access/src/lib/+state/materials.selectors.ts
@@ -1,4 +1,10 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import * as fromMaterials from './materials.reducer';
+import * as materialsReducers from './materials.reducer';
+import { Folder } from '../models/folders.interface';
 
-export const selectMaterialsState = createFeatureSelector<fromMaterials.State>(fromMaterials.materialsFeatureKey);
+export const selectMaterialsState = createFeatureSelector<materialsReducers.MaterialsState>(materialsReducers.MATERIALS_FEATURE_KEY);
+
+export const selectFolders = createSelector(
+  selectMaterialsState,
+  (state): Folder[] => state.folders
+);

--- a/libs/users/materials/data-access/src/lib/models/folders.interface.ts
+++ b/libs/users/materials/data-access/src/lib/models/folders.interface.ts
@@ -1,0 +1,7 @@
+export interface Folder {
+    id: number;
+    created_at: string;
+    title: string;
+}
+
+export type Folders = Folder[];

--- a/libs/users/materials/data-access/src/lib/models/folders.interface.ts
+++ b/libs/users/materials/data-access/src/lib/models/folders.interface.ts
@@ -3,3 +3,7 @@ export interface Folder {
     created_at: string;
     title: string;
 }
+
+export interface newFolder {
+    title: string;
+}

--- a/libs/users/materials/data-access/src/lib/models/folders.interface.ts
+++ b/libs/users/materials/data-access/src/lib/models/folders.interface.ts
@@ -3,5 +3,3 @@ export interface Folder {
     created_at: string;
     title: string;
 }
-
-export type Folders = Folder[];

--- a/libs/users/materials/data-access/src/lib/models/folders.model.ts
+++ b/libs/users/materials/data-access/src/lib/models/folders.model.ts
@@ -1,2 +1,0 @@
-export interface Folders {
-}

--- a/libs/users/materials/data-access/src/lib/models/folders.model.ts
+++ b/libs/users/materials/data-access/src/lib/models/folders.model.ts
@@ -1,0 +1,2 @@
+export interface Folders {
+}

--- a/libs/users/materials/data-access/src/lib/models/materials.interface.ts
+++ b/libs/users/materials/data-access/src/lib/models/materials.interface.ts
@@ -5,3 +5,9 @@ export interface Material {
     material_link: string;
     folder_id: number
 }
+
+export interface newMaterial {
+    title: string;
+    material_link: string;
+    folder_id: number
+}

--- a/libs/users/materials/data-access/src/lib/models/materials.interface.ts
+++ b/libs/users/materials/data-access/src/lib/models/materials.interface.ts
@@ -1,0 +1,9 @@
+export interface Material {
+    id: number
+    created_at: string;
+    title: string;
+    material_link: string;
+    folder_id: number
+}
+
+export type Materials = Material[];

--- a/libs/users/materials/data-access/src/lib/models/materials.interface.ts
+++ b/libs/users/materials/data-access/src/lib/models/materials.interface.ts
@@ -5,5 +5,3 @@ export interface Material {
     material_link: string;
     folder_id: number
 }
-
-export type Materials = Material[];

--- a/libs/users/materials/data-access/src/lib/models/materials.model.ts
+++ b/libs/users/materials/data-access/src/lib/models/materials.model.ts
@@ -1,0 +1,2 @@
+export interface Materials {
+}

--- a/libs/users/materials/data-access/src/lib/models/materials.model.ts
+++ b/libs/users/materials/data-access/src/lib/models/materials.model.ts
@@ -1,2 +1,0 @@
-export interface Materials {
-}

--- a/libs/users/materials/feature-folders-create/.eslintrc.json
+++ b/libs/users/materials/feature-folders-create/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "users",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "users",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/users/materials/feature-folders-create/README.md
+++ b/libs/users/materials/feature-folders-create/README.md
@@ -1,0 +1,7 @@
+# feature-folders-create
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test feature-folders-create` to execute the unit tests.

--- a/libs/users/materials/feature-folders-create/jest.config.ts
+++ b/libs/users/materials/feature-folders-create/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'feature-folders-create',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/users/materials/feature-folders-create',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/users/materials/feature-folders-create/project.json
+++ b/libs/users/materials/feature-folders-create/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "feature-folders-create",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/users/materials/feature-folders-create/src",
+  "prefix": "users",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/users/materials/feature-folders-create/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/users/materials/feature-folders-create/**/*.ts",
+          "libs/users/materials/feature-folders-create/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/users/materials/feature-folders-create/src/index.ts
+++ b/libs/users/materials/feature-folders-create/src/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/feature-folders-create/feature-folders-create.component';
+export * from './lib/feature-folders-create/folders-add-button/folders-add-button.component';
+export * from './lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component';

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/feature-folders-create.component.html
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/feature-folders-create.component.html
@@ -1,0 +1,1 @@
+<p>feature-folders-create works!</p>

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/feature-folders-create.component.spec.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/feature-folders-create.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FeatureFoldersCreateComponent } from './feature-folders-create.component';
+
+describe('FeatureFoldersCreateComponent', () => {
+  let component: FeatureFoldersCreateComponent;
+  let fixture: ComponentFixture<FeatureFoldersCreateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FeatureFoldersCreateComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FeatureFoldersCreateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/feature-folders-create.component.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/feature-folders-create.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-feature-folders-create',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './feature-folders-create.component.html',
+  styleUrls: ['./feature-folders-create.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FeatureFoldersCreateComponent {}

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.html
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.html
@@ -1,0 +1,1 @@
+<p>folders-add-button works!</p>

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.html
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.html
@@ -1,1 +1,8 @@
-<p>folders-add-button works!</p>
+<div class="add-folder-button-container">
+    <button mat-fab (click)="openFolderAddDialog()">
+        <mat-icon>add</mat-icon>
+    </button>
+</div>
+ 
+
+  

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.scss
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.scss
@@ -1,0 +1,5 @@
+.add-folder-button-container {
+    position: absolute;
+    bottom: 16px;
+    right: 16px;
+}

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.spec.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FoldersAddButtonComponent } from './folders-add-button.component';
+
+describe('FoldersAddButtonComponent', () => {
+  let component: FoldersAddButtonComponent;
+  let fixture: ComponentFixture<FoldersAddButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FoldersAddButtonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FoldersAddButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-folders-add-button',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './folders-add-button.component.html',
+  styleUrls: ['./folders-add-button.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FoldersAddButtonComponent {}

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-button/folders-add-button.component.ts
@@ -1,13 +1,41 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import { FoldersAddDialogComponent } from '../folders-add-dialog/folders-add-dialog.component';
+import { newFolder, MaterialsFacade } from '@users/materials/data-access'
 
 @Component({
   selector: 'users-folders-add-button',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatIconModule
+  ],
   templateUrl: './folders-add-button.component.html',
   styleUrls: ['./folders-add-button.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FoldersAddButtonComponent {}
+export class FoldersAddButtonComponent {
+  
+  readonly dialog = inject(MatDialog);
+  private readonly materialsFacade = inject(MaterialsFacade);
+  folder: newFolder | undefined;
+
+  openFolderAddDialog(folder?: newFolder): void {
+    const dialogRef = this.dialog.open(FoldersAddDialogComponent, {
+      data: {folder}
+    });
+
+    dialogRef.afterClosed().subscribe(folder => {
+      if (folder) {
+        this.materialsFacade.createFolder(folder)
+      }
+    });
+  }
+}

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.html
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.html
@@ -1,0 +1,1 @@
+<p>folders-add-dialog works!</p>

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.html
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.html
@@ -1,1 +1,10 @@
-<p>folders-add-dialog works!</p>
+<h2 mat-dialog-title>Folder title</h2>
+<mat-dialog-content>
+  <mat-form-field>
+    <input matInput [(ngModel)]="folder.title" placeholder="Enter folder title" />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">Отмена</button>
+  <button mat-button (click)="onSaveFolder()">Сохранить</button>
+</mat-dialog-actions>

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.spec.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FoldersAddDialogComponent } from './folders-add-dialog.component';
+
+describe('FoldersAddDialogComponent', () => {
+  let component: FoldersAddDialogComponent;
+  let fixture: ComponentFixture<FoldersAddDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FoldersAddDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FoldersAddDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.ts
@@ -1,13 +1,44 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef
+} from '@angular/material/dialog';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { newFolder } from '@users/materials/data-access';
 
 @Component({
   selector: 'users-folders-add-dialog',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    FormsModule,
+    MatButtonModule,
+    MatDialogModule
+  ],
   templateUrl: './folders-add-dialog.component.html',
   styleUrls: ['./folders-add-dialog.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FoldersAddDialogComponent {}
+export class FoldersAddDialogComponent {
+
+  readonly dialogRef = inject(MatDialogRef<FoldersAddDialogComponent>);
+  readonly data = inject(MAT_DIALOG_DATA);
+
+  folder: newFolder = this.data?.folder ?? {title: ''};
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  onSaveFolder(): void {
+    this.dialogRef.close(this.folder);
+  }
+}

--- a/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.ts
+++ b/libs/users/materials/feature-folders-create/src/lib/feature-folders-create/folders-add-dialog/folders-add-dialog.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-folders-add-dialog',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './folders-add-dialog.component.html',
+  styleUrls: ['./folders-add-dialog.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FoldersAddDialogComponent {}

--- a/libs/users/materials/feature-folders-create/src/test-setup.ts
+++ b/libs/users/materials/feature-folders-create/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/users/materials/feature-folders-create/tsconfig.json
+++ b/libs/users/materials/feature-folders-create/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/users/materials/feature-folders-create/tsconfig.lib.json
+++ b/libs/users/materials/feature-folders-create/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/users/materials/feature-folders-create/tsconfig.spec.json
+++ b/libs/users/materials/feature-folders-create/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/users/materials/feature-folders-list/.eslintrc.json
+++ b/libs/users/materials/feature-folders-list/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "users",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "users",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/users/materials/feature-folders-list/README.md
+++ b/libs/users/materials/feature-folders-list/README.md
@@ -1,0 +1,7 @@
+# feature-folders-list
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test feature-folders-list` to execute the unit tests.

--- a/libs/users/materials/feature-folders-list/jest.config.ts
+++ b/libs/users/materials/feature-folders-list/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'feature-folders-list',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/users/materials/feature-folders-list',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/users/materials/feature-folders-list/project.json
+++ b/libs/users/materials/feature-folders-list/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "feature-folders-list",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/users/materials/feature-folders-list/src",
+  "prefix": "users",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/users/materials/feature-folders-list/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/users/materials/feature-folders-list/**/*.ts",
+          "libs/users/materials/feature-folders-list/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/users/materials/feature-folders-list/src/index.ts
+++ b/libs/users/materials/feature-folders-list/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/feature-folders-list/feature-folders-list.component';

--- a/libs/users/materials/feature-folders-list/src/index.ts
+++ b/libs/users/materials/feature-folders-list/src/index.ts
@@ -1,1 +1,4 @@
 export * from './lib/feature-folders-list/feature-folders-list.component';
+export * from './lib/feature-folders-list/folders-card/folders-card.component';
+export * from './lib/feature-folders-list/folders-list/folders-list.component';
+export * from './lib/feature-folders-list/folders-list-container/folders-list-container.component';

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/feature-folders-list.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/feature-folders-list.component.html
@@ -1,0 +1,1 @@
+<p>feature-folders-list works!</p>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/feature-folders-list.component.spec.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/feature-folders-list.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FeatureFoldersListComponent } from './feature-folders-list.component';
+
+describe('FeatureFoldersListComponent', () => {
+  let component: FeatureFoldersListComponent;
+  let fixture: ComponentFixture<FeatureFoldersListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FeatureFoldersListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FeatureFoldersListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/feature-folders-list.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/feature-folders-list.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-feature-folders-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './feature-folders-list.component.html',
+  styleUrls: ['./feature-folders-list.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FeatureFoldersListComponent {}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
@@ -1,4 +1,4 @@
-<div class="folders-card-wrap">
+<div class="folders-card-wrap" (click)="onOpenFolder(folder?.id)">
     <div class="icons-container">
       <mat-icon class="folder-icon">folder</mat-icon>
       <mat-icon class="delete-icon" (click)="onDeleteFolder(folder?.id, $event)">delete</mat-icon>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
@@ -1,0 +1,1 @@
+<p>folders-card works!</p>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
@@ -1,5 +1,8 @@
 <div class="folders-card-wrap">
-    <mat-icon class="folder-icon">folder</mat-icon>
+    <div class="icons-container">
+      <mat-icon class="folder-icon">folder</mat-icon>
+      <mat-icon class="delete-icon" (click)="onDeleteFolder(folder?.id, $event)">delete</mat-icon>
+    </div>
     <div class="folder-content">
       <p class="folder-font-bold">{{ folder?.title }}</p>
       <p>{{ folder?.created_at | date:'d MMMM y' }} y.</p>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
@@ -1,4 +1,8 @@
-<p>folder {{ folder?.title }}</p>
-<p>{{ folder?.created_at }}</p>
-
-
+<div class="folders-card-wrap">
+    <mat-icon class="folder-icon">folder</mat-icon>
+    <div class="folder-content">
+      <p>{{ folder?.title }}</p>
+      <p>{{ folder?.created_at | date:'d MMMM y' }} г.</p>
+    </div>
+  </div>
+  

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
@@ -1,1 +1,4 @@
-<p>folders-card works!</p>
+<p>folder {{ folder?.title }}</p>
+<p>{{ folder?.created_at }}</p>
+
+

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.html
@@ -1,8 +1,8 @@
 <div class="folders-card-wrap">
     <mat-icon class="folder-icon">folder</mat-icon>
     <div class="folder-content">
-      <p>{{ folder?.title }}</p>
-      <p>{{ folder?.created_at | date:'d MMMM y' }} г.</p>
+      <p class="folder-font-bold">{{ folder?.title }}</p>
+      <p>{{ folder?.created_at | date:'d MMMM y' }} y.</p>
     </div>
   </div>
   

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
@@ -1,0 +1,24 @@
+.folders-card-wrap {
+    width: 150px;
+    height: 100px;
+    flex-direction: column;
+    background-color:steelblue;
+    padding: 10px;
+    border-radius: 10px;
+}
+
+.folder-icon {
+    color:wheat;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    font-size: 24px;
+}
+
+.folder-font-bold {
+    font-weight: bold;
+}
+
+p {
+    color: aliceblue;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
@@ -1,6 +1,6 @@
 .folders-card-wrap {
-    width: 150px;
-    height: 100px;
+    width: 155px;
+    height: 105px;
     flex-direction: column;
     background-color:steelblue;
     padding: 10px;

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
@@ -5,6 +5,7 @@
     background-color:steelblue;
     padding: 10px;
     border-radius: 10px;
+    cursor: pointer;
 }
 
 .icons-container {

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.scss
@@ -7,10 +7,28 @@
     border-radius: 10px;
 }
 
+.icons-container {
+    display: flex;
+    justify-content: space-between;
+}
+
 .folder-icon {
     color:wheat;
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
     font-size: 24px;
+}
+
+.delete-icon {
+    color:rgb(245, 179, 179);
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    font-size: 24px;
+    display: none;
+    cursor: pointer;
+    z-index: 100;
+}
+
+.folders-card-wrap:hover .delete-icon {
+    display: block;
 }
 
 .folder-font-bold {

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.spec.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FoldersCardComponent } from './folders-card.component';
+
+describe('FoldersCardComponent', () => {
+  let component: FoldersCardComponent;
+  let fixture: ComponentFixture<FoldersCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FoldersCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FoldersCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Folder } from '@users/materials/data-access';
-import { FeatureFoldersListComponent } from "../feature-folders-list.component";
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
@@ -9,13 +8,18 @@ import { MatIconModule } from '@angular/material/icon';
   standalone: true,
   imports: [
     CommonModule,
-    FeatureFoldersListComponent,
     MatIconModule
-  ],
+],
   templateUrl: './folders-card.component.html',
   styleUrls: ['./folders-card.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FoldersCardComponent {
   @Input() folder: Folder | undefined;
+  @Output() deleteFolder = new EventEmitter();
+
+  onDeleteFolder(folderId?: number, event?: Event): void {
+    event?.stopPropagation();
+    this.deleteFolder.emit(folderId);
+  }
 }

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Folder } from '@users/materials/data-access';
 
 @Component({
   selector: 'users-folders-card',
@@ -9,4 +10,6 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./folders-card.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FoldersCardComponent {}
+export class FoldersCardComponent {
+  @Input() folder: Folder | undefined;
+}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
@@ -17,6 +17,11 @@ import { MatIconModule } from '@angular/material/icon';
 export class FoldersCardComponent {
   @Input() folder: Folder | undefined;
   @Output() deleteFolder = new EventEmitter();
+  @Output() openFolder = new EventEmitter();
+
+  onOpenFolder(folderId?: number): void {
+    this.openFolder.emit(folderId);
+  }
 
   onDeleteFolder(folderId?: number, event?: Event): void {
     event?.stopPropagation();

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
@@ -1,11 +1,17 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Folder } from '@users/materials/data-access';
+import { FeatureFoldersListComponent } from "../feature-folders-list.component";
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'users-folders-card',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    FeatureFoldersListComponent,
+    MatIconModule
+  ],
   templateUrl: './folders-card.component.html',
   styleUrls: ['./folders-card.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-card/folders-card.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-folders-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './folders-card.component.html',
+  styleUrls: ['./folders-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FoldersCardComponent {}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
@@ -1,0 +1,1 @@
+<p>folders-list-container works!</p>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
@@ -1,5 +1,4 @@
-<p>folders-list-container works!</p>
-<div *ngIf="folders$ | async as folders">
+<div class="folders-container" *ngIf="folders$ | async as folders">
     <div *ngFor="let folder of folders">
         <users-folders-card 
             [folder]="folder">

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
@@ -1,7 +1,4 @@
-<div class="folders-container" *ngIf="folders$ | async as folders">
-    <div *ngFor="let folder of folders">
-        <users-folders-card 
-            [folder]="folder">
-        </users-folders-card>
-    </div>
-</div>
+<ng-container *ngIf="folders$ | async as folders">
+    <users-folders-list [folders]="folders" />
+</ng-container>
+  

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
@@ -1,1 +1,8 @@
 <p>folders-list-container works!</p>
+<div *ngIf="folders$ | async as folders">
+    <div *ngFor="let folder of folders">
+        <users-folders-card 
+            [folder]="folder">
+        </users-folders-card>
+    </div>
+</div>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
@@ -1,4 +1,5 @@
 <ng-container *ngIf="folders$ | async as folders">
-    <users-folders-list [folders]="folders" />
+    <users-folders-list [folders]="folders" 
+    (deleteFolder)="onDeleteFolder($event)"/>
 </ng-container>
   

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.html
@@ -1,5 +1,7 @@
 <ng-container *ngIf="folders$ | async as folders">
-    <users-folders-list [folders]="folders" 
+    <users-folders-list
+    [folders]="folders"
+    (openFolder)="onOpenFolder($event)"
     (deleteFolder)="onDeleteFolder($event)"/>
 </ng-container>
   

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.scss
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.scss
@@ -1,0 +1,5 @@
+.folders-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.spec.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FoldersListContainerComponent } from './folders-list-container.component';
+
+describe('FoldersListContainerComponent', () => {
+  let component: FoldersListContainerComponent;
+  let fixture: ComponentFixture<FoldersListContainerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FoldersListContainerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FoldersListContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
@@ -1,8 +1,7 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, inject, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FoldersListContainerStore } from './folders-list-container.store';
-import { FoldersCardComponent } from '../folders-card/folders-card.component';
-import { NgFor, NgIf, AsyncPipe } from '@angular/common';
+import { NgIf, AsyncPipe } from '@angular/common';
 import { FoldersListComponent } from "../folders-list/folders-list.component";
 import { map } from 'rxjs';
 
@@ -11,25 +10,29 @@ import { map } from 'rxjs';
   standalone: true,
   imports: [
     CommonModule,
-    FoldersCardComponent,
-    NgFor,
     NgIf,
     AsyncPipe,
     FoldersListComponent
-],
+  ],
   templateUrl: './folders-list-container.component.html',
   styleUrls: ['./folders-list-container.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [FoldersListContainerStore]
 })
+
 export class FoldersListContainerComponent {
- private readonly componentStore = inject(FoldersListContainerStore)
- public readonly folders$ = this.componentStore.folders$.pipe(
+  private readonly componentStore = inject(FoldersListContainerStore)
+  public readonly folders$ = this.componentStore.folders$.pipe(
   map(folders => folders ?? [])
-);
+  );
+  @Output() deleteFolder = new EventEmitter<number>();
   
   constructor() {
     this.componentStore.loadFolders();
+  }
+
+  onDeleteFolder(folderId: number) {
+    this.componentStore.deleteFolder(folderId);
   }
 
 }

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
@@ -31,8 +31,11 @@ export class FoldersListContainerComponent {
     this.componentStore.loadFolders();
   }
 
+  onOpenFolder(folderId: number) {
+    this.componentStore.openFolder(folderId);
+  }
+  
   onDeleteFolder(folderId: number) {
     this.componentStore.deleteFolder(folderId);
   }
-
 }

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-folders-list-container',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './folders-list-container.component.html',
+  styleUrls: ['./folders-list-container.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FoldersListContainerComponent {}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
@@ -1,12 +1,29 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FoldersListContainerStore } from './folders-list-container.store';
+import { FoldersCardComponent } from '../folders-card/folders-card.component';
+import { NgFor, NgIf, AsyncPipe } from '@angular/common';
 
 @Component({
   selector: 'users-folders-list-container',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    FoldersCardComponent,
+    NgFor,
+    NgIf,
+    AsyncPipe],
   templateUrl: './folders-list-container.component.html',
   styleUrls: ['./folders-list-container.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [FoldersListContainerStore]
 })
-export class FoldersListContainerComponent {}
+export class FoldersListContainerComponent {
+ private readonly componentStore = inject(FoldersListContainerStore)
+  public readonly folders$ = this.componentStore.folders$
+  
+  constructor() {
+    this.componentStore.loadFolders();
+  }
+
+}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.component.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FoldersListContainerStore } from './folders-list-container.store';
 import { FoldersCardComponent } from '../folders-card/folders-card.component';
 import { NgFor, NgIf, AsyncPipe } from '@angular/common';
+import { FoldersListComponent } from "../folders-list/folders-list.component";
+import { map } from 'rxjs';
 
 @Component({
   selector: 'users-folders-list-container',
@@ -12,7 +14,9 @@ import { NgFor, NgIf, AsyncPipe } from '@angular/common';
     FoldersCardComponent,
     NgFor,
     NgIf,
-    AsyncPipe],
+    AsyncPipe,
+    FoldersListComponent
+],
   templateUrl: './folders-list-container.component.html',
   styleUrls: ['./folders-list-container.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -20,7 +24,9 @@ import { NgFor, NgIf, AsyncPipe } from '@angular/common';
 })
 export class FoldersListContainerComponent {
  private readonly componentStore = inject(FoldersListContainerStore)
-  public readonly folders$ = this.componentStore.folders$
+ public readonly folders$ = this.componentStore.folders$.pipe(
+  map(folders => folders ?? [])
+);
   
   constructor() {
     this.componentStore.loadFolders();

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.store.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.store.ts
@@ -1,0 +1,32 @@
+import { inject, Injectable } from '@angular/core';
+import { ComponentStore } from '@ngrx/component-store';
+import { Folder } from '@users/materials/data-access';
+import { MaterialsFacade } from '@users/materials/data-access';
+import { switchMap, tap } from 'rxjs';
+
+export interface FoldersListContainerState {
+  folders: Folder[]
+};
+
+const initialState: FoldersListContainerState = {
+  folders: []
+};
+
+@Injectable({ providedIn: 'root' })
+export class FoldersListContainerStore extends ComponentStore<FoldersListContainerState> {
+  private readonly materialsFacade = inject(MaterialsFacade)
+  public readonly folders$ = this.select(({ folders }) => folders)
+
+  constructor() {
+    super(initialState);
+  }
+
+  readonly loadFolders = this.effect(() =>
+    this.materialsFacade.loadFolders().pipe(
+      switchMap(() => this.materialsFacade.allFolders),
+      tap((folders: Folder[]) => {
+        this.setState({ folders });
+      })
+    )
+  );
+}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.store.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list-container/folders-list-container.store.ts
@@ -5,6 +5,7 @@ import { Folder } from '@users/materials/data-access';
 import { MaterialsFacade } from '@users/materials/data-access';
 import { switchMap, tap } from 'rxjs';
 import { CoreUiConfirmDialogComponent } from '@users/core/ui';
+import { Router } from '@angular/router';
 
 export interface FoldersListContainerState {
   folders: Folder[]
@@ -16,10 +17,11 @@ const initialState: FoldersListContainerState = {
 
 @Injectable({ providedIn: 'root' })
 export class FoldersListContainerStore extends ComponentStore<FoldersListContainerState> {
-  private readonly materialsFacade = inject(MaterialsFacade)
+  private readonly materialsFacade = inject(MaterialsFacade);
   private readonly dialog = inject(MatDialog);
-  public readonly folders$ = this.select(({ folders }) => folders)
-
+  public readonly router = inject(Router);
+  public readonly folders$ = this.select(({ folders }) => folders);
+  
   constructor() {
     super(initialState);
   }
@@ -32,6 +34,11 @@ export class FoldersListContainerStore extends ComponentStore<FoldersListContain
       })
     )
   );
+
+  public openFolder(folderId: number): void {
+    this.materialsFacade.openFolder(folderId)
+    this.router.navigate(['/materials', folderId]);
+  }
 
   public deleteFolder(folderId: number): void {
     this.folders$.pipe(

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
@@ -1,0 +1,1 @@
+<p>folders-list works!</p>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
@@ -2,6 +2,7 @@
     <div *ngFor="let folder of folders">
         <users-folders-card 
             [folder]="folder"
+            (openFolder)="onOpenFolder(folder.id)"
             (deleteFolder)="onDeleteFolder(folder.id)">
         </users-folders-card>
     </div>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
@@ -1,1 +1,7 @@
-<p>folders-list works!</p>
+<div class="folders-container" *ngIf="folders as folders">
+    <div *ngFor="let folder of folders">
+        <users-folders-card 
+            [folder]="folder">
+        </users-folders-card>
+    </div>
+</div>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
@@ -1,7 +1,8 @@
 <div class="folders-container" *ngIf="folders as folders">
     <div *ngFor="let folder of folders">
         <users-folders-card 
-            [folder]="folder">
+            [folder]="folder"
+            (deleteFolder)="onDeleteFolder(folder.id)">
         </users-folders-card>
     </div>
 </div>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.html
@@ -5,3 +5,4 @@
         </users-folders-card>
     </div>
 </div>
+<users-folders-add-button></users-folders-add-button>

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.scss
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.scss
@@ -1,0 +1,5 @@
+.folders-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.spec.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FoldersListComponent } from './folders-list.component';
+
+describe('FoldersListComponent', () => {
+  let component: FoldersListComponent;
+  let fixture: ComponentFixture<FoldersListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FoldersListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FoldersListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FoldersCardComponent } from "../folders-card/folders-card.component";
 import { Folder } from '@users/materials/data-access';
@@ -18,4 +18,9 @@ import { FoldersAddButtonComponent } from '@users/materials/feature-folders-crea
 })
 export class FoldersListComponent {
   @Input() folders: Folder[] = [];
+  @Output() deleteFolder = new EventEmitter<number>();
+
+  onDeleteFolder(folderId: number):void {
+    this.deleteFolder.emit(folderId);
+  }
 }

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
@@ -1,12 +1,16 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FoldersCardComponent } from "../folders-card/folders-card.component";
+import { Folder } from '@users/materials/data-access';
 
 @Component({
   selector: 'users-folders-list',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FoldersCardComponent],
   templateUrl: './folders-list.component.html',
   styleUrls: ['./folders-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FoldersListComponent {}
+export class FoldersListComponent {
+  @Input() folders: Folder[] = [];
+}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-folders-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './folders-list.component.html',
+  styleUrls: ['./folders-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FoldersListComponent {}

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
@@ -19,8 +19,14 @@ import { FoldersAddButtonComponent } from '@users/materials/feature-folders-crea
 export class FoldersListComponent {
   @Input() folders: Folder[] = [];
   @Output() deleteFolder = new EventEmitter<number>();
+  @Output() openFolder = new EventEmitter<number>();
 
+  onOpenFolder(folderId: number):void {
+    this.openFolder.emit(folderId);
+  }
+  
   onDeleteFolder(folderId: number):void {
     this.deleteFolder.emit(folderId);
   }
+
 }

--- a/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
+++ b/libs/users/materials/feature-folders-list/src/lib/feature-folders-list/folders-list/folders-list.component.ts
@@ -2,11 +2,16 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FoldersCardComponent } from "../folders-card/folders-card.component";
 import { Folder } from '@users/materials/data-access';
+import { FoldersAddButtonComponent } from '@users/materials/feature-folders-create'
 
 @Component({
   selector: 'users-folders-list',
   standalone: true,
-  imports: [CommonModule, FoldersCardComponent],
+  imports: [
+    CommonModule,
+    FoldersCardComponent,
+    FoldersAddButtonComponent
+  ],
   templateUrl: './folders-list.component.html',
   styleUrls: ['./folders-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/users/materials/feature-folders-list/src/test-setup.ts
+++ b/libs/users/materials/feature-folders-list/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/users/materials/feature-folders-list/tsconfig.json
+++ b/libs/users/materials/feature-folders-list/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/users/materials/feature-folders-list/tsconfig.lib.json
+++ b/libs/users/materials/feature-folders-list/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/users/materials/feature-folders-list/tsconfig.spec.json
+++ b/libs/users/materials/feature-folders-list/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/users/materials/feature-materials-content/.eslintrc.json
+++ b/libs/users/materials/feature-materials-content/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "users",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "users",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/users/materials/feature-materials-content/README.md
+++ b/libs/users/materials/feature-materials-content/README.md
@@ -1,0 +1,7 @@
+# feature-materials-content
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test feature-materials-content` to execute the unit tests.

--- a/libs/users/materials/feature-materials-content/jest.config.ts
+++ b/libs/users/materials/feature-materials-content/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'feature-materials-content',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/users/materials/feature-materials-content',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/users/materials/feature-materials-content/project.json
+++ b/libs/users/materials/feature-materials-content/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "feature-materials-content",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/users/materials/feature-materials-content/src",
+  "prefix": "users",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/users/materials/feature-materials-content/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/users/materials/feature-materials-content/**/*.ts",
+          "libs/users/materials/feature-materials-content/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/users/materials/feature-materials-content/src/index.ts
+++ b/libs/users/materials/feature-materials-content/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/feature-materials-content/feature-materials-content.component';
+export * from './lib/feature-materials-content/materials-content/materials-content.component';

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/feature-materials-content.component.html
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/feature-materials-content.component.html
@@ -1,0 +1,1 @@
+<p>feature-materials-content works!</p>

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/feature-materials-content.component.spec.ts
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/feature-materials-content.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FeatureMaterialsContentComponent } from './feature-materials-content.component';
+
+describe('FeatureMaterialsContentComponent', () => {
+  let component: FeatureMaterialsContentComponent;
+  let fixture: ComponentFixture<FeatureMaterialsContentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FeatureMaterialsContentComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FeatureMaterialsContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/feature-materials-content.component.ts
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/feature-materials-content.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-feature-materials-content',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './feature-materials-content.component.html',
+  styleUrls: ['./feature-materials-content.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FeatureMaterialsContentComponent {}

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.html
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.html
@@ -1,0 +1,1 @@
+<p>materials-content works!</p>

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.html
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.html
@@ -1,1 +1,46 @@
-<p>materials-content works!</p>
+<h2 mat-dialog-title>{{data.material.title}}</h2>
+<mat-dialog-actions>
+  <button mat-fab mat-dialog-close>
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>
+
+<mat-dialog-content>
+  <ng-container [ngSwitch]="getFileType(data.material.material_link)">
+    <iframe
+      *ngSwitchCase="'youtube'"
+      [src]="getYouTubeEmbedUrl(data.material.material_link)"
+      width="100%"
+      height="500px"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+    <video
+      *ngSwitchCase="'video'"
+      controls
+      [src]="data.material.material_link"
+      style="width: 100%; max-height: 500px;"
+    >
+      Your browser does not support the video tag.
+    </video>
+    <audio
+      *ngSwitchCase="'audio'"
+      controls
+      [src]="data.material.material_link"
+      style="width: 100%;"
+    >
+      Your browser does not support the audio tag.
+    </audio>
+    <pdf-viewer
+      *ngSwitchCase="'pdf'"
+      [src]="data.material.material_link"
+      [render-text]="true"
+      [original-size]="true"
+      style="width: 100%; height: 500px;"
+    ></pdf-viewer>
+    <div *ngSwitchDefault>
+      <p>Unsupported file type or no file provided.</p>
+    </div>
+  </ng-container>
+</mat-dialog-content>

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.scss
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.scss
@@ -1,0 +1,25 @@
+mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-height: 600px;
+  overflow: auto;
+}
+
+iframe,
+video,
+audio,
+pdf-viewer {
+  max-width: 100%;
+}
+
+mat-dialog-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+button[mat-fab] {
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.spec.ts
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialsContentComponent } from './materials-content.component';
+
+describe('MaterialsContentComponent', () => {
+  let component: MaterialsContentComponent;
+  let fixture: ComponentFixture<MaterialsContentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialsContentComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialsContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.ts
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-materials-content',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './materials-content.component.html',
+  styleUrls: ['./materials-content.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MaterialsContentComponent {}

--- a/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.ts
+++ b/libs/users/materials/feature-materials-content/src/lib/feature-materials-content/materials-content/materials-content.component.ts
@@ -1,13 +1,69 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { PdfViewerModule } from 'ng2-pdf-viewer';
+import { MatIconModule } from '@angular/material/icon';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'users-materials-content',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatDialogModule,
+    PdfViewerModule,
+    MatIconModule,
+  ],
   templateUrl: './materials-content.component.html',
   styleUrls: ['./materials-content.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MaterialsContentComponent {}
+export class MaterialsContentComponent {
+  readonly dialogRef = inject(MatDialogRef<MaterialsContentComponent>);
+  readonly data = inject(MAT_DIALOG_DATA);
+  private readonly sanitizer = inject(DomSanitizer);
+
+  getFileType(link: string | undefined): 'video' | 'audio' | 'pdf' | 'youtube' | 'unknown' {
+    if (!link) return 'unknown';
+
+    if (link.includes('youtube.com') || link.includes('youtu.be')) {
+      return 'youtube';
+    }
+
+    const extension = link.split('.').pop()?.toLowerCase();
+    switch (extension) {
+      case 'mp4':
+      case 'webm':
+      case 'ogg':
+        return 'video';
+      case 'mp3':
+      case 'wav':
+      case 'm4a':
+        return 'audio';
+      case 'pdf':
+        return 'pdf';
+      default:
+        return 'unknown';
+    }
+  }
+
+  getYouTubeEmbedUrl(link: string | undefined): SafeResourceUrl | null {
+    if (!link) return null;
+
+    let videoId: string | null = null;
+    if (link.includes('youtube.com/watch')) {
+      const urlParams = new URLSearchParams(link.split('?')[1]);
+      videoId = urlParams.get('v');
+    } else if (link.includes('youtu.be/')) {
+      videoId = link.split('youtu.be/')[1].split(/[\/?]/)[0];
+    }
+    if (videoId) {
+      const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+      return this.sanitizer.bypassSecurityTrustResourceUrl(embedUrl);
+    }
+    return null;
+  }
+}

--- a/libs/users/materials/feature-materials-content/src/test-setup.ts
+++ b/libs/users/materials/feature-materials-content/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/users/materials/feature-materials-content/tsconfig.json
+++ b/libs/users/materials/feature-materials-content/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/users/materials/feature-materials-content/tsconfig.lib.json
+++ b/libs/users/materials/feature-materials-content/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/users/materials/feature-materials-content/tsconfig.spec.json
+++ b/libs/users/materials/feature-materials-content/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/users/materials/feature-materials-create/.eslintrc.json
+++ b/libs/users/materials/feature-materials-create/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "users",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "users",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/users/materials/feature-materials-create/README.md
+++ b/libs/users/materials/feature-materials-create/README.md
@@ -1,0 +1,7 @@
+# feature-materials-create
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test feature-materials-create` to execute the unit tests.

--- a/libs/users/materials/feature-materials-create/jest.config.ts
+++ b/libs/users/materials/feature-materials-create/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'feature-materials-create',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/users/materials/feature-materials-create',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/users/materials/feature-materials-create/project.json
+++ b/libs/users/materials/feature-materials-create/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "feature-materials-create",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/users/materials/feature-materials-create/src",
+  "prefix": "users",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/users/materials/feature-materials-create/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/users/materials/feature-materials-create/**/*.ts",
+          "libs/users/materials/feature-materials-create/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/users/materials/feature-materials-create/src/index.ts
+++ b/libs/users/materials/feature-materials-create/src/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/feature-materials-create/feature-materials-create.component';
+export * from './lib/feature-materials-create/materials-add-button/materials-add-button.component';
+export * from './lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component';

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/feature-materials-create.component.html
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/feature-materials-create.component.html
@@ -1,0 +1,1 @@
+<p>feature-materials-create works!</p>

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/feature-materials-create.component.spec.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/feature-materials-create.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FeatureMaterialsCreateComponent } from './feature-materials-create.component';
+
+describe('FeatureMaterialsCreateComponent', () => {
+  let component: FeatureMaterialsCreateComponent;
+  let fixture: ComponentFixture<FeatureMaterialsCreateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FeatureMaterialsCreateComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FeatureMaterialsCreateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/feature-materials-create.component.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/feature-materials-create.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-feature-materials-create',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './feature-materials-create.component.html',
+  styleUrls: ['./feature-materials-create.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FeatureMaterialsCreateComponent {}

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.html
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.html
@@ -1,1 +1,12 @@
-<p>materials-add-button works!</p>
+<div class="add-material-button-container">
+    <mat-form-field appearance="outline" class="hidden-select">
+        <mat-select #materialSelect [(value)]="selectedMaterialType" (selectionChange)="onMaterialTypeSelected($event.value)" disableRipple>
+            <!-- <mat-option [value]="null">Не выбрано</mat-option> -->
+            <mat-option *ngFor="let option of materialType" [value]="option.value">{{ option.viewValue }}</mat-option>
+        </mat-select>
+    </mat-form-field>
+
+    <button mat-fab (click)="openSelect()" class="custom-trigger-button">
+        <mat-icon>add</mat-icon>
+    </button>
+</div>

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.html
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.html
@@ -1,0 +1,1 @@
+<p>materials-add-button works!</p>

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.scss
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.scss
@@ -1,0 +1,26 @@
+.add-material-button-container {
+    position: absolute;
+    bottom: 16px;
+    right: 180px;
+}
+
+.mat-select-arrow {
+    display: none !important;
+}
+
+.hidden-select {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.hidden-select .mat-select-panel {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+}
+
+.add-material-button-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.spec.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialsAddButtonComponent } from './materials-add-button.component';
+
+describe('MaterialsAddButtonComponent', () => {
+  let component: MaterialsAddButtonComponent;
+  let fixture: ComponentFixture<MaterialsAddButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialsAddButtonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialsAddButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-materials-add-button',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './materials-add-button.component.html',
+  styleUrls: ['./materials-add-button.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MaterialsAddButtonComponent {}

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.ts
@@ -1,13 +1,77 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSelect, MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MaterialsAddDialogComponent } from '../materials-add-dialog/materials-add-dialog.component';
+import { MaterialsFacade } from '@users/materials/data-access';
+
+interface MaterialType {
+  value: string;
+  viewValue: string;
+}
 
 @Component({
   selector: 'users-materials-add-button',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatInputModule,
+    FormsModule
+  ],
   templateUrl: './materials-add-button.component.html',
   styleUrls: ['./materials-add-button.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MaterialsAddButtonComponent {}
+export class MaterialsAddButtonComponent {
+  @Input() folderId: number | null = null;
+
+  @ViewChild('materialSelect') materialSelect!: MatSelect;
+
+  readonly dialog = inject(MatDialog);
+  private readonly materialsFacade = inject(MaterialsFacade);
+
+  materialType: MaterialType[] = [
+    { value: 'pdf', viewValue: 'PDF' },
+    { value: 'video', viewValue: 'Video' },
+    { value: 'audio', viewValue: 'Audio' }
+  ];
+  selectedMaterialType: string | null = null;
+
+  openSelect(): void {
+    if (this.materialSelect) {
+      this.materialSelect.open();
+    }
+  }
+
+  openMaterialAddDialog(value: string): void {
+    const dialogRef = this.dialog.open(MaterialsAddDialogComponent, {
+      data: { folderId: this.folderId ?? 0 }
+    });
+
+    dialogRef.afterClosed().subscribe(material => {
+      if (material) {
+        this.materialsFacade.createMaterial(material);
+      }
+    });
+  }
+
+  onMaterialTypeSelected(value: string | null): void {
+    this.selectedMaterialType = value;
+    this.materialSelect.close();
+    if (value) {
+      this.openMaterialAddDialog(value);
+    }
+  }
+}

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-button/materials-add-button.component.ts
@@ -57,7 +57,10 @@ export class MaterialsAddButtonComponent {
 
   openMaterialAddDialog(value: string): void {
     const dialogRef = this.dialog.open(MaterialsAddDialogComponent, {
-      data: { folderId: this.folderId ?? 0 }
+      data: { 
+        folderId: this.folderId ?? 0,
+        materialType: value
+      }
     });
 
     dialogRef.afterClosed().subscribe(material => {

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
@@ -1,15 +1,26 @@
 <h2 mat-dialog-title>Material title</h2>
-<mat-dialog-content>
+<form [formGroup]="materialsForm" novalidate (ngSubmit)="onSaveMaterial()">
+  <mat-dialog-content>
     <div class="material-add-form-fields">
-        <mat-form-field>
-            <input matInput [(ngModel)]="material.title" placeholder="Enter material`s title" />
-        </mat-form-field>
-        <mat-form-field>
-            <input matInput [(ngModel)]="material.material_link" placeholder="Enter material`s link" />
-        </mat-form-field>
+      <mat-form-field>
+        <mat-label>Enter material's title</mat-label>
+        <input matInput formControlName="title" />
+        <mat-error *ngIf="materialsForm.get('title')?.hasError('required')">
+          Title is required
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Enter material's link</mat-label>
+        <input matInput formControlName="material_link" />
+        <mat-error *ngIf="materialsForm.get('material_link')?.hasError('required')">
+          Link is required
+        </mat-error>
+      </mat-form-field>
+      <input type="hidden" formControlName="folder_id" />
     </div>
-</mat-dialog-content>
-<mat-dialog-actions>
-  <button mat-button (click)="onNoClick()">Отмена</button>
-  <button mat-button (click)="onSaveMaterial()">Сохранить</button>
-</mat-dialog-actions>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <button mat-button type="button" (click)="onNoClick()">Отмена</button>
+    <button mat-button type="submit">Сохранить</button>
+  </mat-dialog-actions>
+</form>

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
@@ -1,0 +1,1 @@
+<p>materials-add-dialog works!</p>

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
@@ -1,1 +1,15 @@
-<p>materials-add-dialog works!</p>
+<h2 mat-dialog-title>Material title</h2>
+<mat-dialog-content>
+    <div class="material-add-form-fields">
+        <mat-form-field>
+            <input matInput [(ngModel)]="material.title" placeholder="Enter material`s title" />
+        </mat-form-field>
+        <mat-form-field>
+            <input matInput [(ngModel)]="material.material_link" placeholder="Enter material`s link" />
+        </mat-form-field>
+    </div>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">Отмена</button>
+  <button mat-button (click)="onSaveMaterial()">Сохранить</button>
+</mat-dialog-actions>

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.html
@@ -15,6 +15,15 @@
         <mat-error *ngIf="materialsForm.get('material_link')?.hasError('required')">
           Link is required
         </mat-error>
+        <mat-error *ngIf="materialsForm.get('material_link')?.hasError('invalidPdf')">
+          Link must be a PDF file (ending with .pdf)
+        </mat-error>
+        <mat-error *ngIf="materialsForm.get('material_link')?.hasError('invalidVideo')">
+          Link must be a YouTube URL
+        </mat-error>
+        <mat-error *ngIf="materialsForm.get('material_link')?.hasError('invalidAudio')">
+          Link must be an audio file (.mp3, .wav, or .ogg)
+        </mat-error>
       </mat-form-field>
       <input type="hidden" formControlName="folder_id" />
     </div>

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.scss
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.scss
@@ -1,0 +1,6 @@
+.material-add-form-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    align-items: center;
+}

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.spec.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialsAddDialogComponent } from './materials-add-dialog.component';
+
+describe('MaterialsAddDialogComponent', () => {
+  let component: MaterialsAddDialogComponent;
+  let fixture: ComponentFixture<MaterialsAddDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialsAddDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialsAddDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.ts
@@ -1,13 +1,47 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef
+} from '@angular/material/dialog';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { newMaterial } from '@users/materials/data-access';
 
 @Component({
   selector: 'users-materials-add-dialog',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    FormsModule,
+    MatButtonModule,
+    MatDialogModule
+  ],
   templateUrl: './materials-add-dialog.component.html',
   styleUrls: ['./materials-add-dialog.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MaterialsAddDialogComponent {}
+export class MaterialsAddDialogComponent {
+  readonly dialogRef = inject(MatDialogRef<MaterialsAddDialogComponent>);
+  readonly data = inject(MAT_DIALOG_DATA);
+
+  material: newMaterial = {
+    title: '',
+    material_link: '',
+    folder_id: this.data?.folderId ?? 0
+  };
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  onSaveMaterial(): void {
+    this.dialogRef.close(this.material);
+  }
+}

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-materials-add-dialog',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './materials-add-dialog.component.html',
+  styleUrls: ['./materials-add-dialog.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MaterialsAddDialogComponent {}

--- a/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.ts
+++ b/libs/users/materials/feature-materials-create/src/lib/feature-materials-create/materials-add-dialog/materials-add-dialog.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -7,7 +7,7 @@ import {
   MatDialogModule,
   MatDialogRef
 } from '@angular/material/dialog';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators, ValidatorFn, AbstractControl, ValidationErrors } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { newMaterial } from '@users/materials/data-access';
 
@@ -18,7 +18,7 @@ import { newMaterial } from '@users/materials/data-access';
     CommonModule,
     MatFormFieldModule,
     MatInputModule,
-    FormsModule,
+    ReactiveFormsModule,
     MatButtonModule,
     MatDialogModule
   ],
@@ -27,21 +27,62 @@ import { newMaterial } from '@users/materials/data-access';
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MaterialsAddDialogComponent {
+export class MaterialsAddDialogComponent implements OnInit {
   readonly dialogRef = inject(MatDialogRef<MaterialsAddDialogComponent>);
   readonly data = inject(MAT_DIALOG_DATA);
 
-  material: newMaterial = {
-    title: '',
-    material_link: '',
-    folder_id: this.data?.folderId ?? 0
-  };
+  materialsForm!: FormGroup;
+
+  ngOnInit() {
+    const materialType = this.data?.materialType ?? '';
+
+    this.materialsForm = new FormGroup({
+      title: new FormControl('', [Validators.required]),
+      material_link: new FormControl('', [
+        Validators.required,
+        this.materialLinkValidator(materialType)
+      ]),
+      folder_id: new FormControl(this.data?.folderId ?? 0)
+    });
+  }
+
+  private materialLinkValidator(materialType: string): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const value = control.value?.toLowerCase() || '';
+      if (!value) return null;
+
+      switch (materialType) {
+        case 'pdf':
+          return value.endsWith('.pdf') ? null : { invalidPdf: true };
+        case 'video':
+          return value.includes('youtube.com') || value.includes('youtu.be')
+            ? null
+            : { invalidVideo: true };
+        case 'audio':
+          return value.endsWith('.mp3') || value.endsWith('.wav') || value.endsWith('.ogg')
+            ? null
+            : { invalidAudio: true };
+        default:
+          return null;
+      }
+    };
+  }
 
   onNoClick(): void {
     this.dialogRef.close();
   }
 
   onSaveMaterial(): void {
-    this.dialogRef.close(this.material);
+    if (this.materialsForm.valid) {
+      const formValue = this.materialsForm.value;
+      const material: newMaterial = {
+        title: formValue.title,
+        material_link: formValue.material_link,
+        folder_id: formValue.folder_id
+      };
+      this.dialogRef.close(material);
+    } else {
+      this.materialsForm.markAllAsTouched();
+    }
   }
 }

--- a/libs/users/materials/feature-materials-create/src/test-setup.ts
+++ b/libs/users/materials/feature-materials-create/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/users/materials/feature-materials-create/tsconfig.json
+++ b/libs/users/materials/feature-materials-create/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/users/materials/feature-materials-create/tsconfig.lib.json
+++ b/libs/users/materials/feature-materials-create/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/users/materials/feature-materials-create/tsconfig.spec.json
+++ b/libs/users/materials/feature-materials-create/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/users/materials/feature-materials-list/.eslintrc.json
+++ b/libs/users/materials/feature-materials-list/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "users",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "users",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/users/materials/feature-materials-list/README.md
+++ b/libs/users/materials/feature-materials-list/README.md
@@ -1,0 +1,7 @@
+# feature-materials-list
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test feature-materials-list` to execute the unit tests.

--- a/libs/users/materials/feature-materials-list/jest.config.ts
+++ b/libs/users/materials/feature-materials-list/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'feature-materials-list',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/users/materials/feature-materials-list',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/users/materials/feature-materials-list/project.json
+++ b/libs/users/materials/feature-materials-list/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "feature-materials-list",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/users/materials/feature-materials-list/src",
+  "prefix": "users",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/users/materials/feature-materials-list/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/users/materials/feature-materials-list/**/*.ts",
+          "libs/users/materials/feature-materials-list/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/users/materials/feature-materials-list/src/index.ts
+++ b/libs/users/materials/feature-materials-list/src/index.ts
@@ -1,0 +1,4 @@
+export * from './lib/feature-materials-list/feature-materials-list.component';
+export * from './lib/feature-materials-list/materials-list/materials-list.component';
+export * from './lib/feature-materials-list/materials-list-container/materials-list-container.component';
+export * from './lib/feature-materials-list/materials-card/materials-card.component';

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/feature-materials-list.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/feature-materials-list.component.html
@@ -1,0 +1,1 @@
+<p>feature-materials-list works!</p>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/feature-materials-list.component.spec.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/feature-materials-list.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FeatureMaterialsListComponent } from './feature-materials-list.component';
+
+describe('FeatureMaterialsListComponent', () => {
+  let component: FeatureMaterialsListComponent;
+  let fixture: ComponentFixture<FeatureMaterialsListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FeatureMaterialsListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FeatureMaterialsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/feature-materials-list.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/feature-materials-list.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-feature-materials-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './feature-materials-list.component.html',
+  styleUrls: ['./feature-materials-list.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FeatureMaterialsListComponent {}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
@@ -1,0 +1,1 @@
+<p>materials-card works!</p>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
@@ -1,13 +1,13 @@
 <div class="materials-card-wrap" (click)="onOpenMaterial(material?.id)">
     <div class="icons-container">
-        <mat-icon class="material-icon">picture_as_pdf</mat-icon>
-        <mat-icon class="material-icon">audiotrack</mat-icon>
-        <mat-icon class="material-icon">video_library</mat-icon>
-        <mat-icon class="delete-icon" (click)="onDeleteMaterial(material?.id, $event)">delete</mat-icon>
+      <mat-icon *ngIf="materialType === 'pdf'" class="material-icon">picture_as_pdf</mat-icon>
+      <mat-icon *ngIf="materialType === 'audio'" class="material-icon">audiotrack</mat-icon>
+      <mat-icon *ngIf="materialType === 'video'" class="material-icon">video_library</mat-icon>
+      <mat-icon *ngIf="materialType === 'unknown'" class="material-icon">help_outline</mat-icon>
+      <mat-icon class="delete-icon" (click)="onDeleteMaterial(material?.id, $event)">delete</mat-icon>
     </div>
     <div class="material-content">
       <p class="material-font-bold">{{ material?.title }}</p>
-      <p>{{ material?.created_at | date:'d MMMM y' }} y.</p>
+      <p>{{ material?.created_at | date:'d MMMM y' }}</p>
     </div>
   </div>
-  

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
@@ -1,1 +1,13 @@
-<p>materials-card works!</p>
+<div class="materials-card-wrap" (click)="onOpenMaterial(material?.id)">
+    <div class="icons-container">
+        <mat-icon class="material-icon">picture_as_pdf</mat-icon>
+        <mat-icon class="material-icon">audiotrack</mat-icon>
+        <mat-icon class="material-icon">video_library</mat-icon>
+        <mat-icon class="delete-icon" (click)="onDeleteMaterial(material?.id, $event)">delete</mat-icon>
+    </div>
+    <div class="material-content">
+      <p class="material-font-bold">{{ material?.title }}</p>
+      <p>{{ material?.created_at | date:'d MMMM y' }} y.</p>
+    </div>
+  </div>
+  

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.html
@@ -1,4 +1,4 @@
-<div class="materials-card-wrap" (click)="onOpenMaterial(material?.id)">
+<div class="materials-card-wrap" (click)="openDialog()">
     <div class="icons-container">
       <mat-icon *ngIf="materialType === 'pdf'" class="material-icon">picture_as_pdf</mat-icon>
       <mat-icon *ngIf="materialType === 'audio'" class="material-icon">audiotrack</mat-icon>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.scss
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.scss
@@ -1,0 +1,42 @@
+.materials-card-wrap {
+    width: 155px;
+    height: 105px;
+    flex-direction: column;
+    background-color:steelblue;
+    padding: 10px;
+    border-radius: 10px;
+    cursor: pointer;
+}
+
+.icons-container {
+    display: flex;
+    justify-content: space-between;
+}
+
+.material-icon {
+    color:wheat;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    font-size: 24px;
+}
+
+.delete-icon {
+    color:rgb(245, 179, 179);
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    font-size: 24px;
+    display: none;
+    cursor: pointer;
+    z-index: 100;
+}
+
+.materials-card-wrap:hover .delete-icon {
+    display: block;
+}
+
+.material-font-bold {
+    font-weight: bold;
+}
+
+p {
+    color: aliceblue;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.spec.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialsCardComponent } from './materials-card.component';
+
+describe('MaterialsCardComponent', () => {
+  let component: MaterialsCardComponent;
+  let fixture: ComponentFixture<MaterialsCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialsCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialsCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
@@ -49,9 +49,7 @@ export class MaterialsCardComponent {
    }
 
    onDeleteMaterial(materialId?: number, event?: Event): void {
-    if (event) {
-      event.stopPropagation();
-    }
-    console.log('onDeleteMaterial', materialId, event);
+    event?.stopPropagation();
+    this.deleteMaterial.emit(materialId);
   }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
@@ -1,8 +1,13 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { Material } from '@users/materials/data-access';
+import { MaterialsContentComponent } from '@users/materials/feature-materials-content'
+import { MatDialog } from '@angular/material/dialog';
 
+export interface DialogData {
+  name: string;
+}
 @Component({
   selector: 'users-materials-card',
   standalone: true,
@@ -17,6 +22,7 @@ import { Material } from '@users/materials/data-access';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MaterialsCardComponent {
+  public dialog = inject(MatDialog)
   @Input() material: Material | undefined;
   @Output() deleteMaterial = new EventEmitter<number>();
   @Output() openMaterial = new EventEmitter<number>();
@@ -27,7 +33,7 @@ export class MaterialsCardComponent {
     this.materialType = this.getMaterialType(this.material?.material_link); 
   }
 
-
+  
   private getMaterialType(link: string | undefined): string | null {
     if (!link) return null;
 
@@ -44,9 +50,15 @@ export class MaterialsCardComponent {
     return 'unknown';
   }
 
-   onOpenMaterial(materialId?: number): void {
-    console.log("onOpenMaterial", materialId)
-   }
+   openDialog(): void {
+    const dialogRef = this.dialog.open(MaterialsContentComponent, {
+      width: '800px',
+      maxWidth: '90vw',
+      data: {material: this.material}
+    });
+
+    dialogRef.afterClosed()
+  }
 
    onDeleteMaterial(materialId?: number, event?: Event): void {
     event?.stopPropagation();

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-materials-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './materials-card.component.html',
+  styleUrls: ['./materials-card.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MaterialsCardComponent {}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { Material } from '@users/materials/data-access';
@@ -18,14 +18,40 @@ import { Material } from '@users/materials/data-access';
 })
 export class MaterialsCardComponent {
   @Input() material: Material | undefined;
-  @Output() deleteFolder = new EventEmitter();
-  @Output() openFolder = new EventEmitter();
+  @Output() deleteMaterial = new EventEmitter<number>();
+  @Output() openMaterial = new EventEmitter<number>();
+
+  materialType: string | null = null;
+
+  ngOnInit() {
+    this.materialType = this.getMaterialType(this.material?.material_link); 
+  }
+
+
+  private getMaterialType(link: string | undefined): string | null {
+    if (!link) return null;
+
+    const lowercaseLink = link.toLowerCase();
+    if (lowercaseLink.includes('youtube.com') || lowercaseLink.includes('youtu.be')) {
+      return 'video';
+    }
+    if (lowercaseLink.endsWith('.pdf')) {
+      return 'pdf';
+    }
+    if (lowercaseLink.endsWith('.mp3') || lowercaseLink.endsWith('.wav') || lowercaseLink.endsWith('.ogg')) {
+      return 'audio';
+    }
+    return 'unknown';
+  }
 
    onOpenMaterial(materialId?: number): void {
     console.log("onOpenMaterial", materialId)
    }
 
    onDeleteMaterial(materialId?: number, event?: Event): void {
-    console.log("onDeleteMaterial", materialId, event)
-   }
+    if (event) {
+      event.stopPropagation();
+    }
+    console.log('onDeleteMaterial', materialId, event);
+  }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-card/materials-card.component.ts
@@ -1,13 +1,31 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { Material } from '@users/materials/data-access';
 
 @Component({
   selector: 'users-materials-card',
   standalone: true,
-  imports: [CommonModule],
+  imports: 
+  [
+    CommonModule,
+    MatIconModule
+  ],
   templateUrl: './materials-card.component.html',
   styleUrls: ['./materials-card.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MaterialsCardComponent {}
+export class MaterialsCardComponent {
+  @Input() material: Material | undefined;
+  @Output() deleteFolder = new EventEmitter();
+  @Output() openFolder = new EventEmitter();
+
+   onOpenMaterial(materialId?: number): void {
+    console.log("onOpenMaterial", materialId)
+   }
+
+   onDeleteMaterial(materialId?: number, event?: Event): void {
+    console.log("onDeleteMaterial", materialId, event)
+   }
+}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
@@ -1,0 +1,1 @@
+<p>materials-list-container works!</p>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
@@ -1,1 +1,6 @@
-<p>materials-list-container works!</p>
+<p>{{folderTitle$ | async}}</p>
+<ng-container *ngIf="materials$ | async as materials">
+    <users-materials-list
+    [materials]="materials"
+    />
+</ng-container>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
@@ -8,5 +8,6 @@
     <users-materials-list 
         [materials]="materials" 
         [folderId]="folder$ | async"
+        (deleteMaterial)="onDeleteMaterial($event)"
     />
 </ng-container>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.html
@@ -1,6 +1,12 @@
-<p>{{folderTitle$ | async}}</p>
+<div class="material-list-header-container">
+    <button mat-button (click)="returnToFolders()">
+        <mat-icon>arrow_back</mat-icon>
+    </button>
+    <span class="folder-title">{{folderTitle$ | async}}</span>
+</div>
 <ng-container *ngIf="materials$ | async as materials">
-    <users-materials-list
-    [materials]="materials"
+    <users-materials-list 
+        [materials]="materials" 
+        [folderId]="folder$ | async"
     />
 </ng-container>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.scss
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.scss
@@ -1,0 +1,16 @@
+.material-list-header-container {
+    display: flex;
+    align-items: center;
+    gap: 8px; /* Уменьшил gap для компактности, можно вернуть 16px */
+    margin-bottom: 16px;
+}
+
+.folder-title {
+    font-size: 24px;
+    font-weight: bold;
+}
+
+.mat-icon {
+    cursor: pointer;
+    font-weight: bold;
+}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.spec.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialsListContainerComponent } from './materials-list-container.component';
+
+describe('MaterialsListContainerComponent', () => {
+  let component: MaterialsListContainerComponent;
+  let fixture: ComponentFixture<MaterialsListContainerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialsListContainerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialsListContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-materials-list-container',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './materials-list-container.component.html',
+  styleUrls: ['./materials-list-container.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MaterialsListContainerComponent {}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
@@ -3,14 +3,20 @@ import { CommonModule } from '@angular/common';
 import { MaterialsListComponent } from '../materials-list/materials-list.component'
 import { MaterialsListContainerStore } from './materials-list-container.store';
 import { map, Subject, takeUntil } from 'rxjs';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
 
 @Component({
   selector: 'users-materials-list-container',
   standalone: true,
   imports: [
     CommonModule,
-    MaterialsListComponent
+    MaterialsListComponent,
+    MatButtonModule,
+    MatIconModule,
+    MatDividerModule
   ],
   templateUrl: './materials-list-container.component.html',
   styleUrls: ['./materials-list-container.component.scss'],
@@ -20,6 +26,7 @@ import { ActivatedRoute } from '@angular/router';
 export class MaterialsListContainerComponent implements OnInit, OnDestroy{
   private readonly componentStore = inject(MaterialsListContainerStore);
   private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   private readonly destroy$ = new Subject<void>(); 
   public readonly materials$ = this.componentStore.materials$.pipe(
   map(materials => materials ?? [])
@@ -44,5 +51,9 @@ export class MaterialsListContainerComponent implements OnInit, OnDestroy{
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  returnToFolders(): void {
+    this.router.navigate(['/materials']);
   }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
@@ -1,13 +1,48 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MaterialsListComponent } from '../materials-list/materials-list.component'
+import { MaterialsListContainerStore } from './materials-list-container.store';
+import { map, Subject, takeUntil } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'users-materials-list-container',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MaterialsListComponent
+  ],
   templateUrl: './materials-list-container.component.html',
   styleUrls: ['./materials-list-container.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MaterialsListContainerComponent {}
+export class MaterialsListContainerComponent implements OnInit, OnDestroy{
+  private readonly componentStore = inject(MaterialsListContainerStore);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroy$ = new Subject<void>(); 
+  public readonly materials$ = this.componentStore.materials$.pipe(
+  map(materials => materials ?? [])
+  );
+  public readonly folder$ = this.componentStore.folderId$
+  public readonly folderTitle$ = this.componentStore.folderTitle$
+  
+  ngOnInit(): void {
+    const snapshotId = Number(this.route.snapshot.params['id']);
+    if (!isNaN(snapshotId) && snapshotId > 0) {
+      this.componentStore.setFolderId(snapshotId);
+    }
+
+    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      const id = Number(params['id']);
+      if (!isNaN(id) && id > 0) {
+        this.componentStore.setFolderId(id);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation, OnInit, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation, OnInit, OnDestroy, EventEmitter, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialsListComponent } from '../materials-list/materials-list.component'
 import { MaterialsListContainerStore } from './materials-list-container.store';
@@ -22,6 +22,7 @@ import { MatDividerModule } from '@angular/material/divider';
   styleUrls: ['./materials-list-container.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [MaterialsListContainerStore]
 })
 export class MaterialsListContainerComponent implements OnInit, OnDestroy{
   private readonly componentStore = inject(MaterialsListContainerStore);
@@ -34,6 +35,8 @@ export class MaterialsListContainerComponent implements OnInit, OnDestroy{
   public readonly folder$ = this.componentStore.folderId$
   public readonly folderTitle$ = this.componentStore.folderTitle$
   
+  @Output() deleteMaterial = new EventEmitter<number>();
+
   ngOnInit(): void {
     const snapshotId = Number(this.route.snapshot.params['id']);
     if (!isNaN(snapshotId) && snapshotId > 0) {
@@ -55,5 +58,9 @@ export class MaterialsListContainerComponent implements OnInit, OnDestroy{
 
   returnToFolders(): void {
     this.router.navigate(['/materials']);
+  }
+
+  onDeleteMaterial(materialId: number) {
+    this.componentStore.deleteMaterial(materialId);
   }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
@@ -23,42 +23,30 @@ export class MaterialsListContainerStore extends ComponentStore<MaterialsListCon
 
   public readonly materials$ = this.select(({ materials }) => materials);
   public readonly folderId$ = this.select(({ folderId }) => folderId);
-  public readonly folderTitle$ = this.select(({ folderTitle }) => folderTitle)
+
+  public readonly folderTitle$ = this.select(
+    this.folderId$,
+    this.materialsFacade.allFolders,
+    (folderId, folders) => {
+      const folder = folders.find((f) => f.id === folderId);
+      return folder ? folder.title : 'Unknown Folder';
+    }
+  );
 
   private readonly validFolderId$: Observable<number> = this.folderId$.pipe(
     filter((id): id is number => !!id)
   );
 
-  readonly updateMaterials = this.updater<Material[]>((state, materials) => ({
-    ...state,
-    materials,
-  }));
-
-  readonly setFolderId = this.updater<number>((state, folderId) => ({
-    ...state,
-    folderId,
-  }));
-
-  readonly setFolderTitle = this.updater<string>((state, folderTitle) => ({
-    ...state,
-    folderTitle,
-  }));
+  readonly updateMaterials = this.updater<Material[]>((state, materials) => ({...state, materials}));
+  readonly setFolderId = this.updater<number>((state, folderId) => ({...state, folderId}));
+  readonly setFolderTitle = this.updater<string>((state, folderTitle) => ({...state, folderTitle}));
 
   readonly loadMaterialsEffect = this.effect<number>((folderId$) =>
     folderId$.pipe(
       switchMap((folderId) =>
         this.materialsFacade.loadMaterials(folderId).pipe(
           map((materials) => materials.filter((material) => material.folder_id === folderId)),
-          withLatestFrom(this.materialsFacade.allFolders),
-          map(([materials, folders]) => {
-            const folder = folders.find((f) => f.id === folderId);
-            const folderTitle = folder ? folder.title : 'Unknown Folder';
-            return { materials, folderTitle };
-          }),
-          tap(({ materials, folderTitle }) => {
-            this.updateMaterials(materials);
-            this.setFolderTitle(folderTitle);
-          })
+          tap((materials) => this.updateMaterials(materials))
         )
       )
     )
@@ -66,6 +54,7 @@ export class MaterialsListContainerStore extends ComponentStore<MaterialsListCon
 
   constructor() {
     super(initialState);
+    this.materialsFacade.loadFolders();
     this.loadMaterialsEffect(this.validFolderId$);
   }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
@@ -2,13 +2,15 @@ import { inject, Injectable } from '@angular/core';
 import { ComponentStore } from '@ngrx/component-store';
 import { Material, MaterialsFacade } from '@users/materials/data-access';
 import { Router } from '@angular/router';
-import { filter, map, Observable, switchMap, tap, withLatestFrom } from 'rxjs';
+import { filter, map, Observable, switchMap, tap, of } from 'rxjs';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { CoreUiConfirmDialogComponent } from '@users/core/ui';
 
 export interface MaterialsListContainerState {
   materials: Material[];
   folderId: number | null;
   folderTitle: string | null;
-};
+}
 
 const initialState: MaterialsListContainerState = {
   materials: [],
@@ -19,6 +21,7 @@ const initialState: MaterialsListContainerState = {
 @Injectable({ providedIn: 'root' })
 export class MaterialsListContainerStore extends ComponentStore<MaterialsListContainerState> {
   private readonly materialsFacade = inject(MaterialsFacade);
+  public readonly dialog = inject(MatDialog);
   public readonly router = inject(Router);
 
   public readonly materials$ = this.select(({ materials }) => materials);
@@ -26,7 +29,7 @@ export class MaterialsListContainerStore extends ComponentStore<MaterialsListCon
 
   public readonly folderTitle$ = this.select(
     this.folderId$,
-    this.materialsFacade.allFolders,
+    this.materialsFacade.allFolders, // Предполагается, что allFolders — Observable
     (folderId, folders) => {
       const folder = folders.find((f) => f.id === folderId);
       return folder ? folder.title : 'Unknown Folder';
@@ -37,9 +40,9 @@ export class MaterialsListContainerStore extends ComponentStore<MaterialsListCon
     filter((id): id is number => !!id)
   );
 
-  readonly updateMaterials = this.updater<Material[]>((state, materials) => ({...state, materials}));
-  readonly setFolderId = this.updater<number>((state, folderId) => ({...state, folderId}));
-  readonly setFolderTitle = this.updater<string>((state, folderTitle) => ({...state, folderTitle}));
+  readonly updateMaterials = this.updater<Material[]>((state, materials) => ({ ...state, materials }));
+  readonly setFolderId = this.updater<number>((state, folderId) => ({ ...state, folderId }));
+  readonly setFolderTitle = this.updater<string>((state, folderTitle) => ({ ...state, folderTitle }));
 
   readonly loadMaterialsByFolderId = this.effect<number>((folderId$) =>
     folderId$.pipe(
@@ -56,5 +59,28 @@ export class MaterialsListContainerStore extends ComponentStore<MaterialsListCon
     super(initialState);
     this.materialsFacade.loadFolders();
     this.loadMaterialsByFolderId(this.validFolderId$);
+  }
+
+  public deleteMaterial(materialId: number): void {
+    this.materials$
+      .pipe(
+        switchMap((materials) => {
+          const material = materials.find((m) => m.id === materialId);
+          if (material) {
+            const dialogRef: MatDialogRef<CoreUiConfirmDialogComponent> = this.dialog.open(
+              CoreUiConfirmDialogComponent,
+              {
+                data: { dialogText: `Вы уверены, что хотите удалить материал ${material.title}?` },
+              }
+            );
+            return dialogRef.afterClosed();
+          }
+          return of(false);
+        }),
+        tap((result: boolean) => {
+          if (result) this.materialsFacade.deleteMaterial(materialId);
+        })
+      )
+      .subscribe();
   }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
@@ -1,0 +1,71 @@
+import { inject, Injectable } from '@angular/core';
+import { ComponentStore } from '@ngrx/component-store';
+import { Material, MaterialsFacade } from '@users/materials/data-access';
+import { Router } from '@angular/router';
+import { filter, map, Observable, switchMap, tap, withLatestFrom } from 'rxjs';
+
+export interface MaterialsListContainerState {
+  materials: Material[];
+  folderId: number | null;
+  folderTitle: string | null;
+};
+
+const initialState: MaterialsListContainerState = {
+  materials: [],
+  folderId: null,
+  folderTitle: null,
+};
+
+@Injectable({ providedIn: 'root' })
+export class MaterialsListContainerStore extends ComponentStore<MaterialsListContainerState> {
+  private readonly materialsFacade = inject(MaterialsFacade);
+  public readonly router = inject(Router);
+
+  public readonly materials$ = this.select(({ materials }) => materials);
+  public readonly folderId$ = this.select(({ folderId }) => folderId);
+  public readonly folderTitle$ = this.select(({ folderTitle }) => folderTitle)
+
+  private readonly validFolderId$: Observable<number> = this.folderId$.pipe(
+    filter((id): id is number => !!id)
+  );
+
+  readonly updateMaterials = this.updater<Material[]>((state, materials) => ({
+    ...state,
+    materials,
+  }));
+
+  readonly setFolderId = this.updater<number>((state, folderId) => ({
+    ...state,
+    folderId,
+  }));
+
+  readonly setFolderTitle = this.updater<string>((state, folderTitle) => ({
+    ...state,
+    folderTitle,
+  }));
+
+  readonly loadMaterialsEffect = this.effect<number>((folderId$) =>
+    folderId$.pipe(
+      switchMap((folderId) =>
+        this.materialsFacade.loadMaterials(folderId).pipe(
+          map((materials) => materials.filter((material) => material.folder_id === folderId)),
+          withLatestFrom(this.materialsFacade.allFolders),
+          map(([materials, folders]) => {
+            const folder = folders.find((f) => f.id === folderId);
+            const folderTitle = folder ? folder.title : 'Unknown Folder';
+            return { materials, folderTitle };
+          }),
+          tap(({ materials, folderTitle }) => {
+            this.updateMaterials(materials);
+            this.setFolderTitle(folderTitle);
+          })
+        )
+      )
+    )
+  );
+
+  constructor() {
+    super(initialState);
+    this.loadMaterialsEffect(this.validFolderId$);
+  }
+}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list-container/materials-list-container.store.ts
@@ -41,7 +41,7 @@ export class MaterialsListContainerStore extends ComponentStore<MaterialsListCon
   readonly setFolderId = this.updater<number>((state, folderId) => ({...state, folderId}));
   readonly setFolderTitle = this.updater<string>((state, folderTitle) => ({...state, folderTitle}));
 
-  readonly loadMaterialsEffect = this.effect<number>((folderId$) =>
+  readonly loadMaterialsByFolderId = this.effect<number>((folderId$) =>
     folderId$.pipe(
       switchMap((folderId) =>
         this.materialsFacade.loadMaterials(folderId).pipe(
@@ -55,6 +55,6 @@ export class MaterialsListContainerStore extends ComponentStore<MaterialsListCon
   constructor() {
     super(initialState);
     this.materialsFacade.loadFolders();
-    this.loadMaterialsEffect(this.validFolderId$);
+    this.loadMaterialsByFolderId(this.validFolderId$);
   }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
@@ -1,0 +1,1 @@
+<p>materials-list works!</p>

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
@@ -3,5 +3,7 @@
         <users-materials-card [material]="material">
         </users-materials-card>
     </div>
+    <div class="add-material-button-container">
+        <users-materials-add-button [folderId]="folderId"></users-materials-add-button>
+    </div>
 </div>
-

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
@@ -1,1 +1,7 @@
-<p>materials-list works!</p>
+<div class="materials-container" *ngIf="materials as materials">
+    <div *ngFor="let material of materials">
+        <users-materials-card [material]="material">
+        </users-materials-card>
+    </div>
+</div>
+

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.html
@@ -1,6 +1,8 @@
 <div class="materials-container" *ngIf="materials as materials">
     <div *ngFor="let material of materials">
-        <users-materials-card [material]="material">
+        <users-materials-card
+            [material]="material"
+            (deleteMaterial)="onDeleteMaterial(material.id)">
         </users-materials-card>
     </div>
     <div class="add-material-button-container">

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.scss
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.scss
@@ -1,0 +1,5 @@
+.materials-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.spec.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialsListComponent } from './materials-list.component';
+
+describe('MaterialsListComponent', () => {
+  let component: MaterialsListComponent;
+  let fixture: ComponentFixture<MaterialsListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialsListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'users-materials-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './materials-list.component.html',
+  styleUrls: ['./materials-list.component.scss'],
+  encapsulation: ViewEncapsulation.Emulated,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MaterialsListComponent {}

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
@@ -2,13 +2,15 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
 import { CommonModule } from '@angular/common';
 import { Material } from '@users/materials/data-access';
 import { MaterialsCardComponent } from '../materials-card/materials-card.component'
+import { MaterialsAddButtonComponent } from '@users/materials/feature-materials-create'
 
 @Component({
   selector: 'users-materials-list',
   standalone: true,
   imports: [
     CommonModule,
-    MaterialsCardComponent
+    MaterialsCardComponent,
+    MaterialsAddButtonComponent
   ],
   templateUrl: './materials-list.component.html',
   styleUrls: ['./materials-list.component.scss'],
@@ -17,4 +19,5 @@ import { MaterialsCardComponent } from '../materials-card/materials-card.compone
 })
 export class MaterialsListComponent {
   @Input() materials: Material[] = [];
+  @Input() folderId: number | null = null;
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Material } from '@users/materials/data-access';
 import { MaterialsCardComponent } from '../materials-card/materials-card.component'
@@ -20,4 +20,9 @@ import { MaterialsAddButtonComponent } from '@users/materials/feature-materials-
 export class MaterialsListComponent {
   @Input() materials: Material[] = [];
   @Input() folderId: number | null = null;
+  @Output() deleteMaterial = new EventEmitter<number>();
+
+  onDeleteMaterial(materialId: number):void {
+    this.deleteMaterial.emit(materialId);
+  }
 }

--- a/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
+++ b/libs/users/materials/feature-materials-list/src/lib/feature-materials-list/materials-list/materials-list.component.ts
@@ -1,13 +1,20 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Material } from '@users/materials/data-access';
+import { MaterialsCardComponent } from '../materials-card/materials-card.component'
 
 @Component({
   selector: 'users-materials-list',
   standalone: true,
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MaterialsCardComponent
+  ],
   templateUrl: './materials-list.component.html',
   styleUrls: ['./materials-list.component.scss'],
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MaterialsListComponent {}
+export class MaterialsListComponent {
+  @Input() materials: Material[] = [];
+}

--- a/libs/users/materials/feature-materials-list/src/test-setup.ts
+++ b/libs/users/materials/feature-materials-list/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/users/materials/feature-materials-list/tsconfig.json
+++ b/libs/users/materials/feature-materials-list/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/users/materials/feature-materials-list/tsconfig.lib.json
+++ b/libs/users/materials/feature-materials-list/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/users/materials/feature-materials-list/tsconfig.spec.json
+++ b/libs/users/materials/feature-materials-list/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "chart.js": "^4.4.0",
         "highcharts": "^11.1.0",
         "highcharts-angular": "^3.1.2",
+        "ng2-pdf-viewer": "^10.4.0",
         "ngx-image-cropper": "^7.0.2",
         "ngx-quill": "^22.0.0",
         "quill": "^1.3.7",
@@ -4702,6 +4703,142 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@material/animation": {
       "version": "15.0.0-canary.bc9ae6c9c.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.bc9ae6c9c.0.tgz",
@@ -9351,7 +9488,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -9623,7 +9760,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/arch": {
       "version": "2.2.0",
@@ -10726,6 +10863,23 @@
         }
       ]
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -11040,7 +11194,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -11188,7 +11342,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -11937,6 +12091,20 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/deep-equal": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
@@ -11964,6 +12132,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -12113,7 +12291,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -12139,6 +12317,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -13161,6 +13349,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "29.6.4",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.4.tgz",
@@ -13999,6 +14197,13 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -14237,7 +14442,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/hdr-histogram-js": {
       "version": "2.0.3",
@@ -18623,6 +18828,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.7.6",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
@@ -18882,6 +19101,13 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -18932,6 +19158,14 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
@@ -18948,6 +19182,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -19494,6 +19735,16 @@
         "nice-napi": "^1.0.2"
       }
     },
+    "node_modules/ng2-pdf-viewer": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ng2-pdf-viewer/-/ng2-pdf-viewer-10.4.0.tgz",
+      "integrity": "sha512-TPh1oLZoeARggreTG60Sl3ikSn+Z3+At9pLZ0o/vxPjc7mW2ok2XPyl2Oqz7VyP80ipVorldm1hsLPBmNe2zzA==",
+      "license": "MIT",
+      "dependencies": {
+        "pdfjs-dist": "4.8.69",
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/ngx-image-cropper": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/ngx-image-cropper/-/ngx-image-cropper-7.0.2.tgz",
@@ -19542,6 +19793,19 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "devOptional": true
     },
+    "node_modules/node-abi": {
+      "version": "3.74.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
+      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -19551,6 +19815,56 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -20910,6 +21224,51 @@
         "node": ">=8"
       }
     },
+    "node_modules/path2d": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
+      "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.8.69",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.8.69.tgz",
+      "integrity": "sha512-IHZsA4T7YElCKNNXtiLgqScw4zPd3pG9do8UrznC757gMd7UPeHSL2qwNNMJo4r79fl8oj1Xx+1nh2YkzdMpLQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^3.0.0-rc2",
+        "path2d": "^0.2.1"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/canvas": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.1.0.tgz",
+      "integrity": "sha512-tTj3CqqukVJ9NgSahykNwtGda7V33VLObwrHfzT0vqJXu7J4d4C/7kQQW3fOEGDfZZoILPut5H00gOjyttPGyg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -22194,6 +22553,88 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -22530,6 +22971,39 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -23285,7 +23759,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -23365,6 +23839,40 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/sisteransi": {
@@ -24092,6 +24600,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -24730,9 +25258,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -26025,7 +26554,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chart.js": "^4.4.0",
     "highcharts": "^11.1.0",
     "highcharts-angular": "^3.1.2",
+    "ng2-pdf-viewer": "^10.4.0",
     "ngx-image-cropper": "^7.0.2",
     "ngx-quill": "^22.0.0",
     "quill": "^1.3.7",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,7 @@
       "@users/home": ["libs/users/home/src/index.ts"],
       "@users/materials": ["libs/users/materials/src/index.ts"],
       "@users/materials/data-access": ["libs/users/materials/data-access/src/index.ts"],
+      "@users/materials/feature-folders-list": ["libs/users/materials/feature-folders-list/src/index.ts"],
       "@users/settings": ["libs/users/settings/src/index.ts"],
       "@users/settings-ui": ["libs/settings-ui/src/index.ts"],
       "@users/settings/data-access": ["libs/users/settings/data-access/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,7 @@
       "@users/home": ["libs/users/home/src/index.ts"],
       "@users/materials": ["libs/users/materials/src/index.ts"],
       "@users/materials/data-access": ["libs/users/materials/data-access/src/index.ts"],
+      "@users/materials/feature-folders-create": ["libs/users/materials/feature-folders-create/src/index.ts"],
       "@users/materials/feature-folders-list": ["libs/users/materials/feature-folders-list/src/index.ts"],
       "@users/settings": ["libs/users/settings/src/index.ts"],
       "@users/settings-ui": ["libs/settings-ui/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,6 +37,7 @@
       "@users/materials/data-access": ["libs/users/materials/data-access/src/index.ts"],
       "@users/materials/feature-folders-create": ["libs/users/materials/feature-folders-create/src/index.ts"],
       "@users/materials/feature-folders-list": ["libs/users/materials/feature-folders-list/src/index.ts"],
+      "@users/materials/feature-materials-list": ["libs/users/materials/feature-materials-list/src/index.ts"],
       "@users/settings": ["libs/users/settings/src/index.ts"],
       "@users/settings-ui": ["libs/settings-ui/src/index.ts"],
       "@users/settings/data-access": ["libs/users/settings/data-access/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,6 +37,7 @@
       "@users/materials/data-access": ["libs/users/materials/data-access/src/index.ts"],
       "@users/materials/feature-folders-create": ["libs/users/materials/feature-folders-create/src/index.ts"],
       "@users/materials/feature-folders-list": ["libs/users/materials/feature-folders-list/src/index.ts"],
+      "@users/materials/feature-materials-create": ["libs/users/materials/feature-materials-create/src/index.ts"],
       "@users/materials/feature-materials-list": ["libs/users/materials/feature-materials-list/src/index.ts"],
       "@users/settings": ["libs/users/settings/src/index.ts"],
       "@users/settings-ui": ["libs/settings-ui/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,6 +37,7 @@
       "@users/materials/data-access": ["libs/users/materials/data-access/src/index.ts"],
       "@users/materials/feature-folders-create": ["libs/users/materials/feature-folders-create/src/index.ts"],
       "@users/materials/feature-folders-list": ["libs/users/materials/feature-folders-list/src/index.ts"],
+      "@users/materials/feature-materials-content": ["libs/users/materials/feature-materials-content/src/index.ts"],
       "@users/materials/feature-materials-create": ["libs/users/materials/feature-materials-create/src/index.ts"],
       "@users/materials/feature-materials-list": ["libs/users/materials/feature-materials-list/src/index.ts"],
       "@users/settings": ["libs/users/settings/src/index.ts"],


### PR DESCRIPTION
This pull request implements the "Materials" section as per the requirements outlined in issue #2. The section introduces a structured way to organize and manage materials within folders, with support for adding folders, materials (videos, PDFs, podcasts), and rendering content-specific previews directly on the page.